### PR TITLE
Add a simple example of setting a key at runtime.

### DIFF
--- a/chitchat-test/src/lib.rs
+++ b/chitchat-test/src/lib.rs
@@ -8,3 +8,8 @@ pub struct ApiResponse {
     pub live_nodes: Vec<NodeId>,
     pub dead_nodes: Vec<NodeId>,
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SetKeyValueResponse {
+    pub status: bool,
+}

--- a/chitchat-test/src/main.rs
+++ b/chitchat-test/src/main.rs
@@ -32,7 +32,7 @@ impl Api {
 
     /// Set a key & value on this node (with no validation).
     #[oai(path = "/set_kv/", method = "get")]
-    async fn named_visitor(
+    async fn set_kv(
         &self,
         key: Query<String>,
         value: Query<String>,

--- a/chitchat-test/src/main.rs
+++ b/chitchat-test/src/main.rs
@@ -32,11 +32,7 @@ impl Api {
 
     /// Set a key & value on this node (with no validation).
     #[oai(path = "/set_kv/", method = "get")]
-    async fn set_kv(
-        &self,
-        key: Query<String>,
-        value: Query<String>,
-    ) -> Json<serde_json::Value> {
+    async fn set_kv(&self, key: Query<String>, value: Query<String>) -> Json<serde_json::Value> {
         let mut chitchat_guard = self.chitchat.lock().await;
 
         let cc_state = chitchat_guard.self_node_state();

--- a/chitchat-test/tests/cli.rs
+++ b/chitchat-test/tests/cli.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{panic, thread};
 
-use chitchat_test::ApiResponse;
+use chitchat_test::{ApiResponse, SetKeyValueResponse};
 use helpers::spawn_command;
 use once_cell::sync::Lazy;
 
@@ -44,6 +44,12 @@ fn get_node_info(node_api_endpoint: &str) -> anyhow::Result<ApiResponse> {
     Ok(response)
 }
 
+fn set_kv(node_api_endpoint: &str, key: &str, value: &str) -> anyhow::Result<SetKeyValueResponse> {
+    let simple_set_kv = format!("{}?key={}&value={}", node_api_endpoint, key, value);
+    let response = reqwest::blocking::get(simple_set_kv)?.json::<SetKeyValueResponse>()?;
+    Ok(response)
+}
+
 #[test]
 fn test_multiple_nodes() -> anyhow::Result<()> {
     panic::set_hook(Box::new(|error| {
@@ -51,6 +57,10 @@ fn test_multiple_nodes() -> anyhow::Result<()> {
         shutdown_nodes();
     }));
     setup_nodes(5, 3);
+
+    // Assert that we can set a key.
+    let set_kv_response = set_kv("http://localhost:10001/set_kv", "some_key", "some_value")?;
+    assert_eq!(set_kv_response.status, true);
 
     // Check node states through api.
     let info = get_node_info("http://localhost:10001")?;
@@ -62,6 +72,16 @@ fn test_multiple_nodes() -> anyhow::Result<()> {
     assert_eq!(info.cluster_id, "testing");
     assert_eq!(info.live_nodes.len(), 4);
     assert_eq!(info.dead_nodes.len(), 0);
+
+    // Check that "some_key" we set on this local node (localhost:10001) is
+    // indeed set to be "some_value"
+    let ns = info
+        .cluster_state
+        .node_states
+        .get("localhost:10001")
+        .unwrap();
+    let v = ns.get_versioned("some_key").unwrap();
+    assert_eq!(v.value, "some_value");
 
     shutdown_nodes();
     Ok(())


### PR DESCRIPTION
I added an additional endpoint to `chitchat-test` to show how to set a nodes key's at runtime.