### PR TITLE
Various refactoring and bug fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
         name: cargo test
         with:
           command: test
-          
+          args: -- --test-threads 1

--- a/chitchat-test/Cargo.toml
+++ b/chitchat-test/Cargo.toml
@@ -17,6 +17,8 @@ anyhow = "1"
 once_cell = "1"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+cool-id-generator = "1"
+env_logger = "0.9"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/chitchat-test/run-servers.sh
+++ b/chitchat-test/run-servers.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+killall chitchat-test
+
+cargo build --release
+
 for i in $(seq 10000 10100)
 do
-    listen_addr="localhost:$i";
+    listen_addr="127.0.0.1:$i";
     echo ${listen_addr};
-    ./target/release/chitchat-test --host ${listen_addr} --seed localhost:10050&
+    cargo run --release -- --listen_addr ${listen_addr} --seed 127.0.0.1:10002 --node_id node_$i &
 done;
 
 read

--- a/chitchat-test/src/main.rs
+++ b/chitchat-test/src/main.rs
@@ -1,8 +1,12 @@
+use std::io;
+use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use chitchat::server::ChitchatServer;
-use chitchat::{Chitchat, FailureDetectorConfig, NodeId, SerializableClusterState};
+use chitchat::{Chitchat, ChitchatConfig, FailureDetectorConfig, NodeId, SerializableClusterState};
 use chitchat_test::ApiResponse;
+use cool_id_generator::Size;
 use poem::listener::TcpListener;
 use poem::{Route, Server};
 use poem_openapi::payload::Json;
@@ -33,26 +37,54 @@ impl Api {
 #[derive(Debug, StructOpt)]
 #[structopt(name = "chitchat", about = "Chitchat test server.")]
 struct Opt {
-    #[structopt(short = "h", default_value = "localhost:10000")]
-    listen_addr: String,
+    /// Defines the socket addr on which we should listen to.
+    #[structopt(long = "listen_addr", default_value = "127.0.0.1:10000")]
+    listen_addr: SocketAddr,
+    /// Defines the socket_address (host:port) other servers should use to
+    /// reach this server.
+    ///
+    /// It defaults to the listen address, but this is only valid
+    /// when all server are running on the same server.
+    #[structopt(long = "public_addr")]
+    public_addr: Option<SocketAddr>,
+
+    /// Node id. Has to be unique. If None, the node_id will be generated from
+    /// the public_addr and a random suffix.
+    #[structopt(long = "node_id")]
+    node_id: Option<String>,
+
     #[structopt(long = "seed")]
     seeds: Vec<String>,
+
+    #[structopt(long = "interval_ms", default_value = "500")]
+    interval: u64,
+}
+
+fn generate_server_id(public_addr: SocketAddr) -> String {
+    let cool_id = cool_id_generator::get_id(Size::Medium);
+    format!("server:{}-{}", public_addr, cool_id)
 }
 
 #[tokio::main]
-async fn main() -> Result<(), std::io::Error> {
+async fn main() -> io::Result<()> {
     tracing_subscriber::fmt::init();
     let opt = Opt::from_args();
     println!("{:?}", opt);
-
-    let chitchat_server = ChitchatServer::spawn(
-        NodeId::from(opt.listen_addr.as_str()),
-        &opt.seeds[..],
-        &opt.listen_addr,
-        "testing".to_string(),
-        Vec::<(&str, &str)>::new(),
-        FailureDetectorConfig::default(),
-    );
+    let public_addr = opt.public_addr.unwrap_or(opt.listen_addr);
+    let node_id_str = opt
+        .node_id
+        .unwrap_or_else(|| generate_server_id(public_addr));
+    let node_id = NodeId::new(node_id_str, public_addr);
+    let config = ChitchatConfig {
+        node_id,
+        cluster_id: "testing".to_string(),
+        gossip_interval: Duration::from_millis(opt.interval),
+        listen_addr: opt.listen_addr,
+        seed_nodes: opt.seeds.clone(),
+        mtu: 60_000,
+        failure_detector_config: FailureDetectorConfig::default(),
+    };
+    let chitchat_server = ChitchatServer::spawn(config, Vec::new()).await;
     let chitchat = chitchat_server.chitchat();
     let api = Api { chitchat };
     let api_service = OpenApiService::new(api, "Hello World", "1.0")

--- a/chitchat-test/tests/cli.rs
+++ b/chitchat-test/tests/cli.rs
@@ -3,40 +3,47 @@
 mod helpers;
 
 use std::process::Child;
-use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::Duration;
-use std::{panic, thread};
 
 use chitchat_test::ApiResponse;
 use helpers::spawn_command;
-use once_cell::sync::Lazy;
 
-type PeersList = Arc<Mutex<Vec<(Child, String)>>>;
+struct KillOnDrop(Child);
 
-static PEERS: Lazy<PeersList> = Lazy::new(|| Arc::new(Mutex::new(Vec::<(Child, String)>::new())));
-
-fn setup_nodes(size: usize, wait_stabilization_secs: u64) {
-    let mut peers_guard = PEERS.lock().unwrap();
-    let seed_port = 10000;
-    let seed_node = spawn_command(format!("-h localhost:{}", seed_port).as_str()).unwrap();
-    peers_guard.push((seed_node, format!("http://localhost:{}", seed_port)));
-    for i in 1..size {
-        let node_port = seed_port + i;
-        let node = spawn_command(
-            format!("-h localhost:{} --seed localhost:{}", node_port, seed_port).as_str(),
-        )
-        .unwrap();
-        peers_guard.push((node, format!("http://localhost:{}", node_port)))
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
     }
-    thread::sleep(Duration::from_secs(wait_stabilization_secs));
 }
 
-fn shutdown_nodes() {
-    let mut peers_guard = PEERS.lock().unwrap();
-    for (node, _) in peers_guard.iter_mut() {
-        let _ = node.kill();
+fn setup_nodes(
+    port_offset: usize,
+    num_nodes: usize,
+    wait_stabilization_secs: u64,
+    dns_required_for_seed: bool,
+) -> Vec<KillOnDrop> {
+    let seed_port = port_offset;
+    let seed_node =
+        spawn_command(format!("--listen_addr 127.0.0.1:{seed_port} --interval_ms 120").as_str())
+            .unwrap();
+    let mut child_process_handles = vec![KillOnDrop(seed_node)];
+    for i in 1..num_nodes {
+        let node_port = seed_port + i;
+        let seed_host_name = if dns_required_for_seed {
+            "localhost"
+        } else {
+            "127.0.0.1"
+        };
+        let command_args = format!(
+            "--listen_addr 127.0.0.1:{node_port} --seed {seed_host_name}:{seed_port} --node_id \
+             node_{i} --interval_ms 50"
+        );
+        let node = spawn_command(&command_args).unwrap();
+        child_process_handles.push(KillOnDrop(node));
     }
-    peers_guard.clear();
+    thread::sleep(Duration::from_secs(wait_stabilization_secs));
+    child_process_handles
 }
 
 fn get_node_info(node_api_endpoint: &str) -> anyhow::Result<ApiResponse> {
@@ -45,24 +52,24 @@ fn get_node_info(node_api_endpoint: &str) -> anyhow::Result<ApiResponse> {
 }
 
 #[test]
-fn test_multiple_nodes() -> anyhow::Result<()> {
-    panic::set_hook(Box::new(|error| {
-        println!("{}", error);
-        shutdown_nodes();
-    }));
-    setup_nodes(5, 3);
-
+fn test_multiple_nodes() {
+    let child_handles = setup_nodes(13_000, 5, 5, false);
+    assert_eq!(child_handles.len(), 5);
     // Check node states through api.
-    let info = get_node_info("http://localhost:10001")?;
-    assert!(info
-        .cluster_state
-        .node_states
-        .get("localhost:10003")
-        .is_some());
+    let info = get_node_info("http://127.0.0.1:13001").unwrap();
+    assert!(info.cluster_state.node_states.get("node_3").is_some());
     assert_eq!(info.cluster_id, "testing");
     assert_eq!(info.live_nodes.len(), 4);
     assert_eq!(info.dead_nodes.len(), 0);
+}
 
-    shutdown_nodes();
-    Ok(())
+#[test]
+fn test_multiple_nodes_with_dns_resolution_for_seed() {
+    let _child_handles = setup_nodes(12_000, 5, 5, true);
+    // Check node states through api.
+    let info = get_node_info("http://127.0.0.1:12001").unwrap();
+    assert!(info.cluster_state.node_states.get("node_3").is_some());
+    assert_eq!(info.cluster_id, "testing");
+    assert_eq!(info.live_nodes.len(), 4);
+    assert_eq!(info.dead_nodes.len(), 0);
 }

--- a/chitchat/src/configuration.rs
+++ b/chitchat/src/configuration.rs
@@ -1,0 +1,47 @@
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use crate::{FailureDetectorConfig, NodeId};
+
+pub struct ChitchatConfig {
+    pub node_id: NodeId,
+    pub cluster_id: String,
+    pub gossip_interval: Duration,
+    pub listen_addr: SocketAddr,
+    pub seed_nodes: Vec<String>,
+    pub mtu: usize,
+    pub failure_detector_config: FailureDetectorConfig,
+}
+
+impl ChitchatConfig {
+    #[cfg(test)]
+    pub fn for_test(port: u16) -> Self {
+        let node_id = NodeId::for_test_localhost(port);
+        let listen_addr = node_id.gossip_public_address;
+        Self {
+            node_id,
+            cluster_id: "default-cluster".to_string(),
+            gossip_interval: Duration::from_millis(50),
+            listen_addr,
+            seed_nodes: Vec::new(),
+            mtu: 60_000,
+            failure_detector_config: Default::default(),
+        }
+    }
+}
+
+impl Default for ChitchatConfig {
+    fn default() -> Self {
+        let node_id = NodeId::for_test_localhost(10_000);
+        let listen_addr = node_id.gossip_public_address;
+        Self {
+            node_id,
+            cluster_id: "default-cluster".to_string(),
+            gossip_interval: Duration::from_millis(1_000),
+            listen_addr,
+            seed_nodes: Vec::new(),
+            mtu: 60_000,
+            failure_detector_config: Default::default(),
+        }
+    }
+}

--- a/chitchat/src/configuration.rs
+++ b/chitchat/src/configuration.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use crate::{FailureDetectorConfig, NodeId};
 
+/// A struct for configuring a Chitact instance.
 pub struct ChitchatConfig {
     pub node_id: NodeId,
     pub cluster_id: String,

--- a/chitchat/src/failure_detector.rs
+++ b/chitchat/src/failure_detector.rs
@@ -70,7 +70,6 @@ impl FailureDetector {
                 garbage_collected_nodes.push(node_id.clone())
             }
         }
-
         for node_id in garbage_collected_nodes.iter() {
             self.dead_nodes.remove(node_id);
         }
@@ -104,7 +103,7 @@ pub struct FailureDetectorConfig {
     pub sampling_window_size: usize,
     /// Heartbeat longer than this will be dropped.
     pub max_interval: Duration,
-    /// Initial interval used on startup when no previous heartbeat exists.  
+    /// Initial interval used on startup when no previous heartbeat exists.
     pub initial_interval: Duration,
     /// Threshold period after which dead node can be removed from the cluster.
     pub dead_node_grace_period: Duration,
@@ -265,9 +264,9 @@ mod tests {
 
         let intervals_choices = vec![1u64, 2];
         let node_ids_choices = vec![
-            NodeId::from("node-1"),
-            NodeId::from("node-2"),
-            NodeId::from("node-3"),
+            NodeId::for_test_localhost(10_001),
+            NodeId::for_test_localhost(10_002),
+            NodeId::for_test_localhost(10_003),
         ];
         for _ in 0..=2000 {
             let time_offset = intervals_choices.choose(&mut rng).unwrap();
@@ -285,7 +284,7 @@ mod tests {
             .map(|node_id| node_id.id.as_str())
             .collect::<Vec<_>>();
         live_nodes.sort_unstable();
-        assert_eq!(live_nodes, vec!["node-1", "node-2", "node-3"]);
+        assert_eq!(live_nodes, vec!["node-10001", "node-10002", "node-10003"]);
         assert_eq!(failure_detector.garbage_collect(), vec![]);
 
         // stop reporting heartbeat for few seconds
@@ -298,7 +297,7 @@ mod tests {
             .map(|node_id| node_id.id.as_str())
             .collect::<Vec<_>>();
         dead_nodes.sort_unstable();
-        assert_eq!(dead_nodes, vec!["node-1", "node-2", "node-3"]);
+        assert_eq!(dead_nodes, vec!["node-10001", "node-10002", "node-10003"]);
         assert_eq!(failure_detector.garbage_collect(), vec![]);
 
         // Wait for dead_node_grace_period & garbage collect.
@@ -323,7 +322,10 @@ mod tests {
             .map(|node_id| node_id.id.as_str())
             .collect::<Vec<_>>();
         removed_nodes.sort_unstable();
-        assert_eq!(removed_nodes, vec!["node-1", "node-2", "node-3"]);
+        assert_eq!(
+            removed_nodes,
+            vec!["node-10001", "node-10002", "node-10003"]
+        );
     }
 
     #[test]
@@ -331,7 +333,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         let mut failure_detector = FailureDetector::new(FailureDetectorConfig::default());
         let intervals_choices = vec![1u64, 2];
-        let node_1 = NodeId::from("node-1");
+        let node_1 = NodeId::for_test_localhost(10_001);
 
         for _ in 0..=2000 {
             let time_offset = intervals_choices.choose(&mut rng).unwrap();
@@ -345,7 +347,7 @@ mod tests {
                 .live_nodes()
                 .map(|node_id| node_id.id.as_str())
                 .collect::<Vec<_>>(),
-            vec!["node-1"]
+            vec!["node-10001"]
         );
 
         // Check node-1 is down (stop reporting heartbeat).
@@ -371,7 +373,7 @@ mod tests {
                 .live_nodes()
                 .map(|node_id| node_id.id.as_str())
                 .collect::<Vec<_>>(),
-            vec!["node-1"]
+            vec!["node-10001"]
         );
     }
 
@@ -379,7 +381,7 @@ mod tests {
     fn test_failure_detector_node_state_after_initial_interval() {
         let mut failure_detector = FailureDetector::new(FailureDetectorConfig::default());
 
-        let node_id = NodeId::from("node-1");
+        let node_id = NodeId::for_test_localhost(10_001);
         failure_detector.report_heartbeat(&node_id);
 
         MockClock::advance(Duration::from_secs(1));
@@ -389,7 +391,7 @@ mod tests {
             .live_nodes()
             .map(|node_id| node_id.id.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(live_nodes, vec!["node-1"]);
+        assert_eq!(live_nodes, vec!["node-10001"]);
         MockClock::advance(Duration::from_secs(40));
         failure_detector.update_node_liveliness(&node_id);
 

--- a/chitchat/src/lib.rs
+++ b/chitchat/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod server;
 
+mod configuration;
 mod delta;
 mod digest;
 mod failure_detector;
@@ -8,6 +9,7 @@ pub(crate) mod serialize;
 mod state;
 
 use std::collections::HashSet;
+use std::net::SocketAddr;
 
 use delta::Delta;
 use failure_detector::FailureDetector;
@@ -17,6 +19,7 @@ use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 use tracing::{debug, error, warn};
 
+pub use self::configuration::ChitchatConfig;
 use crate::digest::Digest;
 use crate::message::ChitchatMessage;
 use crate::serialize::Serializable;
@@ -61,32 +64,33 @@ pub type Version = u64;
 /// Note: using timestamp to make the `id` dynamic has the potential of reusing
 /// a previously used `id` in cases where the clock is reset in the past. We believe this
 /// very rare and things should just work fine.
-#[derive(Default, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+#[derive(Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 pub struct NodeId {
     // The unique identifier of this node in the cluster.
     pub id: String,
     // The SocketAddr other peers should use to communicate.
-    pub gossip_public_address: String,
+    pub gossip_public_address: SocketAddr,
 }
 
 impl NodeId {
-    pub fn new(id: String, gossip_public_address: String) -> Self {
+    pub fn new(id: String, gossip_public_address: SocketAddr) -> Self {
         Self {
             id,
             gossip_public_address,
         }
     }
-}
 
-impl From<&str> for NodeId {
-    fn from(id: &str) -> Self {
-        Self::new(id.to_string(), id.to_string())
+    pub fn for_test_localhost(port: u16) -> Self {
+        NodeId::new(
+            format!("node-{port}"),
+            ([127u8, 0u8, 0u8, 1u8], port).into(),
+        )
     }
-}
 
-impl From<String> for NodeId {
-    fn from(id: String) -> Self {
-        Self::new(id.clone(), id)
+    /// Returns the gossip public port. Useful for test assert only.
+    #[cfg(test)]
+    pub fn public_port(&self) -> u16 {
+        self.gossip_public_address.port()
     }
 }
 
@@ -98,10 +102,7 @@ pub struct VersionedValue {
 }
 
 pub struct Chitchat {
-    mtu: usize,
-    address: String,
-    self_node_id: NodeId,
-    cluster_id: String,
+    config: ChitchatConfig,
     cluster_state: ClusterState,
     heartbeat: u64,
     /// The failure detector instance.
@@ -114,22 +115,17 @@ pub struct Chitchat {
 
 impl Chitchat {
     pub fn with_node_id_and_seeds(
-        self_node_id: NodeId,
-        seed_ids: HashSet<String>,
-        address: String,
-        cluster_id: String,
-        initial_key_values: Vec<(impl ToString, impl ToString)>,
-        failure_detector_config: FailureDetectorConfig,
+        config: ChitchatConfig,
+        seed_addrs: watch::Receiver<HashSet<SocketAddr>>,
+        initial_key_values: Vec<(String, String)>,
     ) -> Self {
         let (live_nodes_watcher_tx, live_nodes_watcher_rx) = watch::channel(HashSet::new());
+        let failure_detector = FailureDetector::new(config.failure_detector_config.clone());
         let mut chitchat = Chitchat {
-            mtu: 60_000,
-            address,
-            self_node_id,
-            cluster_id,
-            cluster_state: ClusterState::with_seed_ids(seed_ids),
+            config,
+            cluster_state: ClusterState::with_seed_addrs(seed_addrs),
             heartbeat: 0,
-            failure_detector: FailureDetector::new(failure_detector_config),
+            failure_detector,
             live_nodes_watcher_tx,
             live_nodes_watcher_rx,
         };
@@ -147,14 +143,10 @@ impl Chitchat {
         chitchat
     }
 
-    pub fn set_mtu(&mut self, mtu: usize) {
-        self.mtu = mtu;
-    }
-
     pub fn create_syn_message(&mut self) -> ChitchatMessage {
         let digest = self.compute_digest();
         ChitchatMessage::Syn {
-            cluster_id: self.cluster_id.clone(),
+            cluster_id: self.config.cluster_id.clone(),
             digest,
         }
     }
@@ -162,7 +154,7 @@ impl Chitchat {
     pub fn process_message(&mut self, msg: ChitchatMessage) -> Option<ChitchatMessage> {
         match msg {
             ChitchatMessage::Syn { cluster_id, digest } => {
-                if cluster_id != self.cluster_id {
+                if cluster_id != self.config.cluster_id {
                     warn!(
                         cluster_id = %cluster_id,
                         "rejecting syn message with mismatching cluster name"
@@ -174,7 +166,7 @@ impl Chitchat {
                 let dead_nodes = self.dead_nodes().collect::<HashSet<_>>();
                 let delta = self.cluster_state.compute_delta(
                     &digest,
-                    self.mtu - 1 - self_digest.serialized_len(),
+                    self.config.mtu - 1 - self_digest.serialized_len(),
                     dead_nodes,
                 );
                 self.report_to_failure_detector(&delta);
@@ -187,9 +179,9 @@ impl Chitchat {
                 self.report_to_failure_detector(&delta);
                 self.cluster_state.apply_delta(delta);
                 let dead_nodes = self.dead_nodes().collect::<HashSet<_>>();
-                let delta = self
-                    .cluster_state
-                    .compute_delta(&digest, self.mtu - 1, dead_nodes);
+                let delta =
+                    self.cluster_state
+                        .compute_delta(&digest, self.config.mtu - 1, dead_nodes);
                 Some(ChitchatMessage::Ack { delta })
             }
             ChitchatMessage::Ack { delta } => {
@@ -226,7 +218,7 @@ impl Chitchat {
         let cluster_nodes = self
             .cluster_state
             .nodes()
-            .filter(|node_id| *node_id != &self.self_node_id)
+            .filter(|node_id| *node_id != self.self_node_id())
             .collect::<Vec<_>>();
         for node_id in &cluster_nodes {
             self.failure_detector.update_node_liveliness(node_id);
@@ -234,16 +226,16 @@ impl Chitchat {
 
         let live_nodes_after = self.live_nodes().cloned().collect::<HashSet<_>>();
         if live_nodes_before != live_nodes_after {
-            debug!(current_node = ?self.self_node_id, live_nodes = ?live_nodes_after, "nodes status changed");
+            debug!(current_node = ?self.self_node_id(), live_nodes = ?live_nodes_after, "nodes status changed");
             if self.live_nodes_watcher_tx.send(live_nodes_after).is_err() {
-                error!(current_node = ?self.self_node_id, "error while reporting membership change event.")
+                error!(current_node = ?self.self_node_id(), "error while reporting membership change event.")
             }
         }
 
         // Perform garbage collection.
         let garbage_collected_nodes = self.failure_detector.garbage_collect();
         for node_id in garbage_collected_nodes.iter() {
-            self.cluster_state.remove_node(node_id)
+            self.cluster_state.remove_node(node_id);
         }
     }
 
@@ -252,7 +244,7 @@ impl Chitchat {
     }
 
     pub fn self_node_state(&mut self) -> &mut NodeState {
-        self.cluster_state.node_state_mut(&self.self_node_id)
+        self.cluster_state.node_state_mut(&self.config.node_id)
     }
 
     /// Retrieves the list of all live nodes.
@@ -266,16 +258,16 @@ impl Chitchat {
     }
 
     /// Retrieve a list of seed nodes.
-    pub fn seed_nodes(&self) -> impl Iterator<Item = &str> {
-        self.cluster_state.seed_nodes()
+    pub fn seed_nodes(&self) -> HashSet<SocketAddr> {
+        self.cluster_state.seed_addrs()
     }
 
     pub fn self_node_id(&self) -> &NodeId {
-        &self.self_node_id
+        &self.config.node_id
     }
 
     pub fn cluster_id(&self) -> &str {
-        &self.cluster_id
+        &self.config.cluster_id
     }
 
     /// Computes digest.
@@ -292,8 +284,8 @@ impl Chitchat {
         self.cluster_state.compute_digest(dead_nodes)
     }
 
-    pub fn cluster_state(&self) -> ClusterState {
-        self.cluster_state.clone()
+    pub fn cluster_state(&self) -> &ClusterState {
+        &self.cluster_state
     }
 
     /// Returns a watch stream for monitoring changes on the cluster's live nodes.
@@ -317,7 +309,7 @@ mod tests {
     use super::*;
     use crate::server::ChitchatServer;
 
-    const DEAD_NODE_GRACE_PERIOD: Duration = Duration::from_secs(25);
+    const DEAD_NODE_GRACE_PERIOD: Duration = Duration::from_secs(20);
 
     fn run_chitchat_handshake(initiating_node: &mut Chitchat, peer_node: &mut Chitchat) {
         let syn_message = initiating_node.create_syn_message();
@@ -348,34 +340,35 @@ mod tests {
         }
     }
 
-    fn start_node(port: u32, seeds: &[String]) -> ChitchatServer {
-        let address = format!("localhost:{}", port);
-        ChitchatServer::spawn(
-            NodeId::from(address.as_str()),
-            seeds,
-            address,
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig {
+    async fn start_node(node_id: NodeId, seeds: &[String]) -> ChitchatServer {
+        let config = ChitchatConfig {
+            node_id: node_id.clone(),
+            cluster_id: "default-cluster".to_string(),
+            gossip_interval: Duration::from_millis(50),
+            listen_addr: node_id.gossip_public_address,
+            seed_nodes: seeds.to_vec(),
+            mtu: 60_000,
+            failure_detector_config: FailureDetectorConfig {
                 dead_node_grace_period: DEAD_NODE_GRACE_PERIOD,
+                phi_threshold: 5.0,
                 ..Default::default()
             },
-        )
+        };
+        let initial_kvs: Vec<(String, String)> = Vec::new();
+        ChitchatServer::spawn(config, initial_kvs).await
     }
 
-    async fn setup_nodes(port_range: RangeInclusive<u32>) -> Vec<(String, ChitchatServer)> {
-        let mut tasks = Vec::new();
-        let mut ports = port_range.clone();
-        let seed_port = ports.next().unwrap();
-        tasks.push((seed_port.to_string(), start_node(seed_port, &[])));
-        for port in ports {
-            let seeds = port_range
-                .clone()
-                .filter(|peer_port| peer_port != &port)
-                .map(|peer_port| format!("localhost:{}", peer_port))
+    async fn setup_nodes(port_range: RangeInclusive<u16>) -> Vec<ChitchatServer> {
+        let node_ids: Vec<NodeId> = port_range.map(NodeId::for_test_localhost).collect();
+        let node_without_seed = start_node(node_ids[0].clone(), &[]).await;
+        let mut chitchat_servers: Vec<ChitchatServer> = vec![node_without_seed];
+        for node_id in &node_ids[1..] {
+            let seeds = node_ids
+                .iter()
+                .filter(|&peer_id| peer_id != node_id)
+                .map(|peer_id| peer_id.gossip_public_address.to_string())
                 .collect::<Vec<_>>();
-
-            tasks.push((port.to_string(), start_node(port, &seeds)));
+            chitchat_servers.push(start_node(node_id.clone(), &seeds).await);
         }
         // Make sure the failure detector's fake clock moves forward.
         tokio::spawn(async {
@@ -384,11 +377,11 @@ mod tests {
                 MockClock::advance(Duration::from_millis(50));
             }
         });
-        tasks
+        chitchat_servers
     }
 
-    async fn shutdown_nodes(nodes: Vec<(String, ChitchatServer)>) -> anyhow::Result<()> {
-        for (_, node) in nodes {
+    async fn shutdown_nodes(nodes: Vec<ChitchatServer>) -> anyhow::Result<()> {
+        for node in nodes {
             node.shutdown().await?;
         }
         Ok(())
@@ -417,25 +410,26 @@ mod tests {
 
     #[test]
     fn test_chitchat_handshake() {
+        let node_config1 = ChitchatConfig::for_test(10_001);
+        let empty_seeds = watch::channel(Default::default()).1;
         let mut node1 = Chitchat::with_node_id_and_seeds(
-            NodeId::from("node1"),
-            HashSet::new(),
-            "node1".to_string(),
-            "test-cluster".to_string(),
-            vec![("key1a", "1"), ("key2a", "2")],
-            FailureDetectorConfig::default(),
+            node_config1,
+            empty_seeds.clone(),
+            vec![
+                ("key1a".to_string(), "1".to_string()),
+                ("key2a".to_string(), "2".to_string()),
+            ],
         );
+        let node_config2 = ChitchatConfig::for_test(10_002);
         let mut node2 = Chitchat::with_node_id_and_seeds(
-            NodeId::from("node2"),
-            HashSet::new(),
-            "node2".to_string(),
-            "test-cluster".to_string(),
-            vec![("key1b", "1"), ("key2b", "2")],
-            FailureDetectorConfig::default(),
+            node_config2,
+            empty_seeds,
+            vec![
+                ("key1b".to_string(), "1".to_string()),
+                ("key2b".to_string(), "2".to_string()),
+            ],
         );
         run_chitchat_handshake(&mut node1, &mut node2);
-        dbg!(&node1.cluster_state());
-        dbg!(&node2.cluster_state());
         assert_nodes_sync(&[&node1, &node2]);
         // useless handshake
         run_chitchat_handshake(&mut node1, &mut node2);
@@ -453,16 +447,16 @@ mod tests {
     async fn test_multiple_nodes() -> anyhow::Result<()> {
         let nodes = setup_nodes(20001..=20005).await;
 
-        let (id, node) = nodes.get(1).unwrap();
-        assert_eq!(id, "20002");
+        let node = nodes.get(1).unwrap();
+        assert_eq!(node.node_id().public_port(), 20002);
         wait_for_chitchat_state(
             node.chitchat(),
             4,
             &[
-                NodeId::from("localhost:20001"),
-                NodeId::from("localhost:20003"),
-                NodeId::from("localhost:20004"),
-                NodeId::from("localhost:20005"),
+                NodeId::for_test_localhost(20001),
+                NodeId::for_test_localhost(20003),
+                NodeId::for_test_localhost(20004),
+                NodeId::for_test_localhost(20005),
             ],
         )
         .await;
@@ -474,59 +468,63 @@ mod tests {
     #[tokio::test]
     async fn test_node_goes_from_live_to_down_to_live() -> anyhow::Result<()> {
         let mut nodes = setup_nodes(30001..=30006).await;
-
-        let (id, node) = nodes.get(1).unwrap();
-        assert_eq!(id, "30002");
+        let node = &nodes[1];
+        assert_eq!(node.node_id().gossip_public_address.port(), 30002);
         wait_for_chitchat_state(
             node.chitchat(),
             5,
             &[
-                NodeId::from("localhost:30001"),
-                NodeId::from("localhost:30003"),
-                NodeId::from("localhost:30004"),
-                NodeId::from("localhost:30005"),
-                NodeId::from("localhost:30006"),
+                NodeId::for_test_localhost(30001),
+                NodeId::for_test_localhost(30003),
+                NodeId::for_test_localhost(30004),
+                NodeId::for_test_localhost(30005),
+                NodeId::for_test_localhost(30006),
             ],
         )
         .await;
 
         // Take down node at localhost:30003
-        let (id, node) = nodes.remove(2);
-        assert_eq!(id, "30003");
+        let node = nodes.remove(2);
+        assert_eq!(node.node_id().public_port(), 30003);
         node.shutdown().await.unwrap();
 
-        let (id, node) = nodes.get(1).unwrap();
-        assert_eq!(id, "30002");
+        let node = nodes.get(1).unwrap();
+        assert_eq!(node.node_id().public_port(), 30002);
         wait_for_chitchat_state(
             node.chitchat(),
             4,
             &[
-                NodeId::from("localhost:30001"),
-                NodeId::from("localhost:30004"),
-                NodeId::from("localhost:30005"),
-                NodeId::from("localhost:30006"),
+                NodeId::for_test_localhost(30001),
+                NodeId::for_test_localhost(30004),
+                NodeId::for_test_localhost(30005),
+                NodeId::for_test_localhost(30006),
             ],
         )
         .await;
 
         // Restart node at localhost:10003
-        let port = 30003;
-        nodes.push((
-            port.to_string(),
-            start_node(port, &["localhost:30001".to_string()]),
-        ));
+        let node_3 = NodeId::for_test_localhost(30003);
+        nodes.push(
+            start_node(
+                node_3,
+                &[NodeId::for_test_localhost(30_001)
+                    .gossip_public_address
+                    .to_string()],
+            )
+            .await,
+        );
 
-        let (id, node) = nodes.get(1).unwrap();
-        assert_eq!(id, "30002");
+        let node = nodes.get(1).unwrap();
+        assert_eq!(node.node_id().public_port(), 30002);
         wait_for_chitchat_state(
             node.chitchat(),
             5,
             &[
-                NodeId::from("localhost:30001"),
-                NodeId::from("localhost:30003"),
-                NodeId::from("localhost:30004"),
-                NodeId::from("localhost:30005"),
-                NodeId::from("localhost:30006"),
+                NodeId::for_test_localhost(30001),
+                NodeId::for_test_localhost(30003),
+                NodeId::for_test_localhost(30004),
+                NodeId::for_test_localhost(30005),
+                NodeId::for_test_localhost(30006),
             ],
         )
         .await;
@@ -538,79 +536,76 @@ mod tests {
     #[tokio::test]
     async fn test_dead_node_should_not_be_gossiped_when_node_joins() -> anyhow::Result<()> {
         let mut nodes = setup_nodes(40001..=40004).await;
-
-        let (id, node) = nodes.get(1).unwrap();
-        assert_eq!(id, "40002");
-        wait_for_chitchat_state(
-            node.chitchat(),
-            3,
-            &[
-                NodeId::from("localhost:40001"),
-                NodeId::from("localhost:40003"),
-                NodeId::from("localhost:40004"),
-            ],
-        )
-        .await;
+        {
+            let node2 = nodes.get(1).unwrap();
+            assert_eq!(node2.node_id().public_port(), 40002);
+            wait_for_chitchat_state(
+                node2.chitchat(),
+                3,
+                &[
+                    NodeId::for_test_localhost(40001),
+                    NodeId::for_test_localhost(40003),
+                    NodeId::for_test_localhost(40004),
+                ],
+            )
+            .await;
+        }
 
         // Take down node at localhost:40003
-        let (id, node) = nodes.remove(2);
-        assert_eq!(id, "40003");
-        node.shutdown().await.unwrap();
+        let node3 = nodes.remove(2);
+        assert_eq!(node3.node_id().public_port(), 40003);
+        node3.shutdown().await.unwrap();
 
-        let (id, node) = nodes.get(1).unwrap();
-        assert_eq!(id, "40002");
-        wait_for_chitchat_state(
-            node.chitchat(),
-            2,
-            &[
-                NodeId::from("localhost:40001"),
-                NodeId::from("localhost:40004"),
-            ],
-        )
-        .await;
+        {
+            let node2 = nodes.get(1).unwrap();
+            assert_eq!(node2.node_id().public_port(), 40002);
+            wait_for_chitchat_state(
+                node2.chitchat(),
+                2,
+                &[
+                    NodeId::for_test_localhost(40_001),
+                    NodeId::for_test_localhost(40_004),
+                ],
+            )
+            .await;
+        }
 
         // Restart node at localhost:40003 with new name
-        let port = 40003;
-        let address = format!("localhost:{}", port);
-        let new_node_chitchat = ChitchatServer::spawn(
-            NodeId::new("new_node".to_string(), address.clone()),
-            &["localhost:40001".to_string()],
-            address,
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
-        nodes.push((port.to_string(), new_node_chitchat));
+        let mut new_config = ChitchatConfig::for_test(40_003);
+        new_config.node_id.id = "new_node".to_string();
+        let seed = NodeId::for_test_localhost(40_002).gossip_public_address;
+        new_config.seed_nodes = vec![seed.to_string()];
+        let new_node_chitchat = ChitchatServer::spawn(new_config, Vec::new()).await;
 
-        let (id, node) = nodes.get(3).unwrap();
-        assert_eq!(id, "40003");
         wait_for_chitchat_state(
-            node.chitchat(),
+            new_node_chitchat.chitchat(),
             3,
             &[
-                NodeId::from("localhost:40001"),
-                NodeId::from("localhost:40002"),
-                NodeId::from("localhost:40004"),
+                NodeId::for_test_localhost(40_001),
+                NodeId::for_test_localhost(40_002),
+                NodeId::for_test_localhost(40_004),
             ],
         )
         .await;
 
+        nodes.push(new_node_chitchat);
         shutdown_nodes(nodes).await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn test_network_partition_nodes() -> anyhow::Result<()> {
-        let nodes = setup_nodes(11001..=11006).await;
+        let port_range = 11_001u16..=11_006;
+        let nodes = setup_nodes(port_range.clone()).await;
 
         // Check nodes know each other.
-        for (id, node) in nodes.iter() {
-            let peers = (11001u32..=11006)
-                .filter(|peer_port| peer_port.to_string() != *id)
-                .map(|peer_port| NodeId::from(format!("localhost:{}", peer_port)))
+        for node in nodes.iter() {
+            let expected_peers: Vec<NodeId> = port_range
+                .clone()
+                .filter(|peer_port| *peer_port != node.node_id().public_port())
+                .map(NodeId::for_test_localhost)
                 .collect::<Vec<_>>();
-
-            wait_for_chitchat_state(node.chitchat(), 5, &peers.to_vec()).await;
+            wait_for_chitchat_state(node.chitchat(), 5, &expected_peers).await;
         }
 
         shutdown_nodes(nodes).await?;
@@ -620,44 +615,43 @@ mod tests {
     #[tokio::test]
     async fn test_dead_node_garbage_collection() -> anyhow::Result<()> {
         let mut nodes = setup_nodes(60001..=60006).await;
-
-        let (id, node) = nodes.get(1).unwrap();
-        assert_eq!(id, "60002");
+        let node = nodes.get(1).unwrap();
+        assert_eq!(node.node_id().public_port(), 60002);
         wait_for_chitchat_state(
             node.chitchat(),
             5,
             &[
-                NodeId::from("localhost:60001"),
-                NodeId::from("localhost:60003"),
-                NodeId::from("localhost:60004"),
-                NodeId::from("localhost:60005"),
-                NodeId::from("localhost:60006"),
+                NodeId::for_test_localhost(60_001),
+                NodeId::for_test_localhost(60_003),
+                NodeId::for_test_localhost(60_004),
+                NodeId::for_test_localhost(60_005),
+                NodeId::for_test_localhost(60_006),
             ],
         )
         .await;
 
         // Take down node at localhost:60003
-        let (id, node) = nodes.remove(2);
-        assert_eq!(id, "60003");
+        let node = nodes.remove(2);
+        assert_eq!(node.node_id().public_port(), 60003);
         node.shutdown().await.unwrap();
 
-        let (id, node) = nodes.get(1).unwrap();
-        assert_eq!(id, "60002");
+        let node = nodes.get(1).unwrap();
+        assert_eq!(node.node_id().public_port(), 60002);
         wait_for_chitchat_state(
             node.chitchat(),
             4,
             &[
-                NodeId::from("localhost:60001"),
-                NodeId::from("localhost:60004"),
-                NodeId::from("localhost:60005"),
-                NodeId::from("localhost:60006"),
+                NodeId::for_test_localhost(60_001),
+                NodeId::for_test_localhost(60_004),
+                NodeId::for_test_localhost(60_005),
+                NodeId::for_test_localhost(60_006),
             ],
         )
         .await;
 
         // Dead node should still be known to the cluster.
-        let dead_node_id = NodeId::from("localhost:60003");
-        for (_, node) in nodes.iter() {
+        let dead_node_id = NodeId::for_test_localhost(60003);
+        for node in &nodes {
             assert!(node
                 .chitchat()
                 .lock()
@@ -668,11 +662,11 @@ mod tests {
 
         // Wait a bit more than `dead_node_grace_period` since all nodes will not
         // notice cluster change at the same time.
-        let wait_for = DEAD_NODE_GRACE_PERIOD.add(Duration::from_secs(15));
+        let wait_for = DEAD_NODE_GRACE_PERIOD.add(Duration::from_secs(20));
         time::sleep(wait_for).await;
 
         // Dead node should no longer be known to the cluster.
-        for (_, node) in nodes.iter() {
+        for node in &nodes {
             assert!(node
                 .chitchat()
                 .lock()

--- a/chitchat/src/message.rs
+++ b/chitchat/src/message.rs
@@ -117,18 +117,18 @@ impl Serializable for ChitchatMessage {
 #[cfg(test)]
 mod tests {
     use crate::serialize::test_serdeser_aux;
-    use crate::{ChitchatMessage, Digest};
+    use crate::{ChitchatMessage, Digest, NodeId};
 
     #[test]
     fn test_syn() {
         let mut digest = Digest::default();
-        digest.add_node("node1".into(), 1);
-        digest.add_node("node2".into(), 2);
+        digest.add_node(NodeId::for_test_localhost(10_001), 1);
+        digest.add_node(NodeId::for_test_localhost(10_002), 2);
         let syn = ChitchatMessage::Syn {
             cluster_id: "cluster-a".to_string(),
             digest,
         };
-        test_serdeser_aux(&syn, 58);
+        test_serdeser_aux(&syn, 68);
     }
 
     #[test]

--- a/chitchat/src/server.rs
+++ b/chitchat/src/server.rs
@@ -78,7 +78,7 @@ async fn resolve_seed_host(seed_host: &str, seed_addrs: &mut HashSet<SocketAddr>
 // in order to avoid having a split cluster.
 //
 // The newcomers are supposed to chime in too,
-// so there is not need to refresh it too often,
+// so there is no need to refresh it too often,
 // especially if it is not empty.
 async fn spawn_dns_refresh_loop(seeds: &[String]) -> watch::Receiver<HashSet<SocketAddr>> {
     let mut seed_addrs_not_requiring_resolution: HashSet<SocketAddr> = Default::default();

--- a/chitchat/src/server.rs
+++ b/chitchat/src/server.rs
@@ -4,73 +4,148 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rand::prelude::*;
-use tokio::net::UdpSocket;
+use tokio::net::{lookup_host, ToSocketAddrs, UdpSocket};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use tokio::sync::Mutex;
+use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
 use tokio::time;
-use tracing::error;
+use tracing::{debug, error, info, warn};
 
-use crate::failure_detector::FailureDetectorConfig;
 use crate::message::ChitchatMessage;
 use crate::serialize::Serializable;
-use crate::{Chitchat, NodeId};
+use crate::{Chitchat, ChitchatConfig, NodeId};
 
 /// Maximum payload size (in bytes) for UDP.
 const UDP_MTU: usize = 65_507;
-
-/// Interval between random gossip.
-const GOSSIP_INTERVAL: Duration = if cfg!(test) {
-    Duration::from_millis(200)
-} else {
-    Duration::from_secs(1)
-};
 
 /// Number of nodes picked for random gossip.
 const GOSSIP_COUNT: usize = 3;
 
 /// UDP Chitchat server.
 pub struct ChitchatServer {
-    channel: UnboundedSender<ChannelMessage>,
+    node_id: NodeId,
+    command_tx: UnboundedSender<Command>,
     chitchat: Arc<Mutex<Chitchat>>,
     join_handle: JoinHandle<Result<(), anyhow::Error>>,
+}
+
+const DNS_POLLING_DURATION: Duration = Duration::from_secs(60);
+
+async fn dns_refresh_loop(
+    seed_hosts_requiring_dns: HashSet<String>,
+    seed_addrs_not_requiring_resolution: HashSet<SocketAddr>,
+    seed_addrs_tx: watch::Sender<HashSet<SocketAddr>>,
+) {
+    let mut interval = time::interval(DNS_POLLING_DURATION);
+    // We actually do not want to run the polling loop right away,
+    // hence this tick.
+    interval.tick().await;
+    while seed_addrs_tx.receiver_count() > 0 {
+        interval.tick().await;
+        let mut seed_addrs = seed_addrs_not_requiring_resolution.clone();
+        for seed_host in &seed_hosts_requiring_dns {
+            resolve_seed_host(seed_host, &mut seed_addrs).await;
+        }
+        if seed_addrs_tx.send(seed_addrs).is_err() {
+            return;
+        }
+    }
+}
+
+async fn resolve_seed_host(seed_host: &str, seed_addrs: &mut HashSet<SocketAddr>) {
+    if let Ok(resolved_seed_addrs) = lookup_host(seed_host).await {
+        for seed_addr in resolved_seed_addrs {
+            if seed_addrs.contains(&seed_addr) {
+                continue;
+            }
+            debug!(seed_host=seed_host, seed_addr=%seed_addr, "seed-addr-from_dns");
+            seed_addrs.insert(seed_addr);
+        }
+    } else {
+        warn!(seed_host=%seed_host, "Failed to lookup host");
+    }
+}
+
+// The seed nodes address can be string representing a
+// socket addr directly, or hostnames:port.
+//
+// The latter is especially important when relying on
+// a headless service in k8s or when using DNS in general.
+//
+// In that case, we do not want to perform the resolution
+// once and forall.
+// We want to periodically retry DNS resolution,
+// in order to avoid having a split cluster.
+//
+// The newcomers are supposed to chime in too,
+// so there is not need to refresh it too often,
+// especially if it is not empty.
+async fn spawn_dns_refresh_loop(seeds: &[String]) -> watch::Receiver<HashSet<SocketAddr>> {
+    let mut seed_addrs_not_requiring_resolution: HashSet<SocketAddr> = Default::default();
+    let mut first_round_seed_resolution: HashSet<SocketAddr> = Default::default();
+    let mut seed_requiring_dns: HashSet<String> = Default::default();
+    for seed in seeds {
+        if let Ok(seed_addr) = seed.parse() {
+            seed_addrs_not_requiring_resolution.insert(seed_addr);
+        } else {
+            seed_requiring_dns.insert(seed.clone());
+            // We run DNS resolution for the first iteration too.
+            // It will be run in the DNS polling loop too, but running
+            // it for the first iteration makes sure our first gossip
+            // round will not be for nothing.
+            resolve_seed_host(seed, &mut first_round_seed_resolution).await;
+        }
+    }
+
+    let initial_seed_addrs: HashSet<SocketAddr> = seed_addrs_not_requiring_resolution
+        .union(&first_round_seed_resolution)
+        .cloned()
+        .collect();
+
+    info!(initial_seed_addrs=?initial_seed_addrs);
+
+    let (seed_addrs_tx, seed_addrs_rx) = watch::channel(initial_seed_addrs);
+    if !seed_requiring_dns.is_empty() {
+        tokio::task::spawn(dns_refresh_loop(
+            seed_requiring_dns,
+            seed_addrs_not_requiring_resolution,
+            seed_addrs_tx,
+        ));
+    }
+    seed_addrs_rx
 }
 
 impl ChitchatServer {
     /// Launch a new server.
     ///
     /// This will start the Chitchat server as a new Tokio background task.
-    pub fn spawn(
-        node_id: NodeId,
-        seed_nodes: &[String],
-        address: impl Into<String>,
-        cluster_id: String,
-        initial_key_values: Vec<(impl ToString, impl ToString)>,
-        failure_detector_config: FailureDetectorConfig,
-    ) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel();
+    pub async fn spawn(config: ChitchatConfig, initial_key_values: Vec<(String, String)>) -> Self {
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
 
-        let chitchat = Chitchat::with_node_id_and_seeds(
-            node_id,
-            seed_nodes.iter().cloned().collect(),
-            address.into(),
-            cluster_id,
-            initial_key_values,
-            failure_detector_config,
-        );
+        let seed_addrs: watch::Receiver<HashSet<SocketAddr>> =
+            spawn_dns_refresh_loop(&config.seed_nodes).await;
+
+        let node_id = config.node_id.clone();
+
+        let chitchat = Chitchat::with_node_id_and_seeds(config, seed_addrs, initial_key_values);
         let chitchat_arc = Arc::new(Mutex::new(chitchat));
         let chitchat_server = chitchat_arc.clone();
 
         let join_handle = tokio::spawn(async move {
-            let mut server = UdpServer::new(rx, chitchat_server).await?;
+            let mut server = UdpServer::new(command_rx, chitchat_server).await?;
             server.run().await
         });
 
         Self {
-            channel: tx,
+            node_id,
+            command_tx,
             chitchat: chitchat_arc,
             join_handle,
         }
+    }
+
+    pub fn node_id(&self) -> &NodeId {
+        &self.node_id
     }
 
     pub fn chitchat(&self) -> Arc<Mutex<Chitchat>> {
@@ -86,46 +161,43 @@ impl ChitchatServer {
 
     /// Shut the server down.
     pub async fn shutdown(self) -> Result<(), anyhow::Error> {
-        let _ = self.channel.send(ChannelMessage::Shutdown);
+        let _ = self.command_tx.send(Command::Shutdown);
         self.join_handle.await?
     }
 
     /// Perform a Chitchat "handshake" with another UDP server.
     pub fn gossip(&self, addr: impl Into<String>) -> Result<(), anyhow::Error> {
-        self.channel.send(ChannelMessage::Gossip(addr.into()))?;
+        self.command_tx.send(Command::Gossip(addr.into()))?;
         Ok(())
     }
 }
 
 /// UDP server for Chitchat communication.
 struct UdpServer {
-    channel: UnboundedReceiver<ChannelMessage>,
+    command_rx: UnboundedReceiver<Command>,
     chitchat: Arc<Mutex<Chitchat>>,
-    socket: Arc<UdpSocket>,
+    socket: UdpSocket,
 }
 
 impl UdpServer {
     async fn new(
-        channel: UnboundedReceiver<ChannelMessage>,
+        command_rx: UnboundedReceiver<Command>,
         chitchat: Arc<Mutex<Chitchat>>,
     ) -> anyhow::Result<Self> {
-        let socket = {
-            let bind_address = &chitchat.lock().await.address;
-            Arc::new(UdpSocket::bind(bind_address).await?)
-        };
-
+        let bind_address = chitchat.lock().await.config.listen_addr;
+        let socket = UdpSocket::bind(bind_address).await?;
         Ok(Self {
             chitchat,
-            channel,
+            command_rx,
             socket,
         })
     }
 
     /// Listen for new Chitchat messages.
     async fn run(&mut self) -> anyhow::Result<()> {
-        let mut gossip_interval = time::interval(GOSSIP_INTERVAL);
-        let mut rng = SmallRng::from_entropy();
-
+        let gossip_interval = self.chitchat.lock().await.config.gossip_interval;
+        let mut gossip_interval = time::interval(gossip_interval);
+        let mut rng = SmallRng::from_rng(thread_rng()).expect("Failed to seed random generator");
         let mut buf = [0; UDP_MTU];
         loop {
             tokio::select! {
@@ -136,11 +208,11 @@ impl UdpServer {
                     Err(err) => return Err(err.into()),
                 },
                 _ = gossip_interval.tick() => self.gossip_multiple(&mut rng).await,
-                message = self.channel.recv() => match message {
-                    Some(ChannelMessage::Gossip(addr)) => {
+                message = self.command_rx.recv() => match message {
+                    Some(Command::Gossip(addr)) => {
                         let _ = self.gossip(addr).await;
                     },
-                    Some(ChannelMessage::Shutdown) | None => break,
+                    Some(Command::Shutdown) | None => break,
                 },
             }
         }
@@ -172,17 +244,17 @@ impl UdpServer {
         let peer_nodes = cluster_state
             .nodes()
             .filter(|node_id| *node_id != chitchat_guard.self_node_id())
-            .map(|node_id| node_id.gossip_public_address.as_str())
+            .map(|node_id| node_id.gossip_public_address)
             .collect::<HashSet<_>>();
         let live_nodes = chitchat_guard
             .live_nodes()
-            .map(|node_id| node_id.gossip_public_address.as_str())
+            .map(|node_id| node_id.gossip_public_address)
             .collect::<HashSet<_>>();
         let dead_nodes = chitchat_guard
             .dead_nodes()
-            .map(|node_id| node_id.gossip_public_address.as_str())
+            .map(|node_id| node_id.gossip_public_address)
             .collect::<HashSet<_>>();
-        let seed_nodes = chitchat_guard.seed_nodes().collect::<HashSet<_>>();
+        let seed_nodes: HashSet<SocketAddr> = chitchat_guard.seed_nodes();
         let (selected_nodes, random_dead_node_opt, random_seed_node_opt) =
             select_nodes_for_gossip(rng, peer_nodes, live_nodes, dead_nodes, seed_nodes);
 
@@ -216,65 +288,61 @@ impl UdpServer {
     }
 
     /// Gossip to one other UDP server.
-    async fn gossip(&self, addr: impl Into<String>) -> anyhow::Result<()> {
+    async fn gossip(&self, addr: impl ToSocketAddrs) -> anyhow::Result<()> {
         let syn = self.chitchat.lock().await.create_syn_message();
         let mut buf = Vec::new();
         syn.serialize(&mut buf);
-        let _ = self.socket.send_to(&buf, addr.into()).await?;
+        let _ = self.socket.send_to(&buf, addr).await?;
         Ok(())
     }
 }
 
 #[derive(Debug)]
-enum ChannelMessage {
+enum Command {
     Gossip(String),
     Shutdown,
 }
 
 fn select_nodes_for_gossip<R>(
     rng: &mut R,
-    peer_nodes: HashSet<&str>,
-    live_nodes: HashSet<&str>,
-    dead_nodes: HashSet<&str>,
-    seed_nodes: HashSet<&str>,
-) -> (Vec<String>, Option<String>, Option<String>)
+    peer_nodes: HashSet<SocketAddr>,
+    live_nodes: HashSet<SocketAddr>,
+    dead_nodes: HashSet<SocketAddr>,
+    seed_nodes: HashSet<SocketAddr>,
+) -> (Vec<SocketAddr>, Option<SocketAddr>, Option<SocketAddr>)
 where
     R: Rng + ?Sized,
 {
     let live_nodes_count = live_nodes.len();
     let dead_nodes_count = dead_nodes.len();
-    const EMPTY_STRING: String = String::new();
-    let mut rand_nodes = [EMPTY_STRING; GOSSIP_COUNT];
 
     // Select `GOSSIP_COUNT` number of live nodes.
     // On startup, select from cluster nodes since we don't know any live node yet.
-    let count = if live_nodes_count == 0 {
+    let nodes = if live_nodes_count == 0 {
         peer_nodes
-            .iter()
-            .map(ToString::to_string)
-            .choose_multiple_fill(rng, &mut rand_nodes)
     } else {
         live_nodes
-            .iter()
-            .map(ToString::to_string)
-            .choose_multiple_fill(rng, &mut rand_nodes)
-    };
-    let mut nodes = Vec::new();
+    }
+    .iter()
+    .cloned()
+    .choose_multiple(rng, GOSSIP_COUNT);
+
     let mut has_gossiped_with_a_seed_node = false;
-    for node_id in &rand_nodes[..count] {
-        has_gossiped_with_a_seed_node =
-            has_gossiped_with_a_seed_node || seed_nodes.contains(node_id.as_str());
-        nodes.push((*node_id).clone());
+    for node_id in &nodes {
+        if seed_nodes.contains(node_id) {
+            has_gossiped_with_a_seed_node = true;
+            break;
+        }
     }
 
     // Select a dead node for potential gossip.
-    let random_dead_node_opt =
+    let random_dead_node_opt: Option<SocketAddr> =
         select_dead_node_to_gossip_with(rng, &dead_nodes, live_nodes_count, dead_nodes_count);
 
     // Select a seed node for potential gossip.
     // It prevents network partition caused by the number of seeds.
     // See https://issues.apache.org/jira/browse/CASSANDRA-150
-    let random_seed_node_opt =
+    let random_seed_node_opt: Option<SocketAddr> =
         if !has_gossiped_with_a_seed_node || live_nodes_count < seed_nodes.len() {
             select_seed_node_to_gossip_with(rng, &seed_nodes, live_nodes_count, dead_nodes_count)
         } else {
@@ -287,16 +355,16 @@ where
 /// Selects a dead node to gossip with, with some probability.
 fn select_dead_node_to_gossip_with<R>(
     rng: &mut R,
-    dead_nodes: &HashSet<&str>,
+    dead_nodes: &HashSet<SocketAddr>,
     live_nodes_count: usize,
     dead_nodes_count: usize,
-) -> Option<String>
+) -> Option<SocketAddr>
 where
     R: Rng + ?Sized,
 {
     let selection_probability = dead_nodes_count as f64 / (live_nodes_count + 1) as f64;
     if selection_probability > rng.gen::<f64>() {
-        return dead_nodes.iter().choose(rng).map(ToString::to_string);
+        return dead_nodes.iter().choose(rng).cloned();
     }
     None
 }
@@ -304,22 +372,17 @@ where
 /// Selects a seed node to gossip with, with some probability.
 fn select_seed_node_to_gossip_with<R>(
     rng: &mut R,
-    seed_nodes: &HashSet<&str>,
+    seed_nodes: &HashSet<SocketAddr>,
     live_nodes_count: usize,
     dead_nodes_count: usize,
-) -> Option<String>
+) -> Option<SocketAddr>
 where
     R: Rng + ?Sized,
 {
-    let random_seed_node = seed_nodes.iter().choose(rng).map(ToString::to_string);
-    if live_nodes_count == 0 {
-        return random_seed_node;
-    }
-
     let selection_probability =
         seed_nodes.len() as f64 / (live_nodes_count + dead_nodes_count) as f64;
-    if selection_probability >= rng.gen::<f64>() {
-        return random_seed_node;
+    if live_nodes_count == 0 || rng.gen::<f64>() <= selection_probability {
+        return seed_nodes.iter().choose(rng).cloned();
     }
     None
 }
@@ -332,7 +395,6 @@ mod tests {
     use tokio_stream::StreamExt;
 
     use super::*;
-    use crate::failure_detector::FailureDetectorConfig;
     use crate::message::ChitchatMessage;
     use crate::HEARTBEAT_KEY;
 
@@ -361,8 +423,8 @@ mod tests {
         }
     }
 
-    fn to_hash_set<'a>(node_ids: &[&'a str]) -> std::collections::HashSet<&'a str> {
-        node_ids.iter().copied().collect()
+    fn to_hash_set<T: Eq + std::hash::Hash>(node_ids: Vec<T>) -> std::collections::HashSet<T> {
+        node_ids.into_iter().collect()
     }
 
     async fn timeout<O>(future: impl Future<Output = O>) -> O {
@@ -372,18 +434,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn syn() {
+    async fn test_syn() {
         let test_addr = "0.0.0.0:1111";
         let socket = UdpSocket::bind(test_addr).await.unwrap();
-
-        let server = ChitchatServer::spawn(
-            "0.0.0.0:1112".into(),
-            &[],
-            "0.0.0.0:1112",
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
+        let config = ChitchatConfig::for_test(1112);
+        let server = ChitchatServer::spawn(config, Vec::new()).await;
         server.gossip(test_addr).unwrap();
 
         let mut buf = [0; UDP_MTU];
@@ -392,7 +447,7 @@ mod tests {
         let msg = ChitchatMessage::deserialize(&mut &buf[..len]).unwrap();
         match msg {
             ChitchatMessage::Syn { cluster_id, digest } => {
-                assert_eq!(cluster_id, "test-cluster");
+                assert_eq!(cluster_id, "default-cluster");
                 assert_eq!(digest.node_max_version.len(), 1);
             }
             message => panic!("unexpected message: {:?}", message),
@@ -401,32 +456,30 @@ mod tests {
         server.shutdown().await.unwrap();
     }
 
-    #[tokio::test]
-    async fn syn_ack() {
-        let server_addr = "0.0.0.0:2221";
-        let socket = UdpSocket::bind("0.0.0.0:2222").await.unwrap();
-        let mut chitchat = Chitchat::with_node_id_and_seeds(
-            "offline".into(),
-            HashSet::new(),
-            "offline".to_string(),
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
+    #[cfg(test)]
+    fn empty_seeds() -> watch::Receiver<HashSet<SocketAddr>> {
+        watch::channel(Default::default()).1
+    }
 
-        let server = ChitchatServer::spawn(
-            server_addr.into(),
-            &[],
-            server_addr,
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
+    #[tokio::test]
+    async fn test_syn_ack() {
+        let node_2 = NodeId::for_test_localhost(2221);
+        let config1 = ChitchatConfig::for_test(2222);
+        let socket = UdpSocket::bind(config1.listen_addr).await.unwrap();
+        let mut chitchat = Chitchat::with_node_id_and_seeds(
+            ChitchatConfig::for_test(2222),
+            empty_seeds(),
+            Vec::new(),
         );
+        let server = ChitchatServer::spawn(ChitchatConfig::for_test(2221), Vec::new()).await;
 
         let mut buf = Vec::new();
         let syn = chitchat.create_syn_message();
         syn.serialize(&mut buf);
-        socket.send_to(&buf[..], server_addr).await.unwrap();
+        socket
+            .send_to(&buf[..], node_2.gossip_public_address)
+            .await
+            .unwrap();
 
         let mut buf = [0; super::UDP_MTU];
         let (len, _addr) = timeout(socket.recv_from(&mut buf)).await.unwrap();
@@ -441,27 +494,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn syn_bad_cluster() {
-        let outsider_addr = "0.0.0.0:2224";
-        let socket = UdpSocket::bind(outsider_addr).await.unwrap();
-        let mut outsider = Chitchat::with_node_id_and_seeds(
-            outsider_addr.into(),
-            HashSet::new(),
-            outsider_addr.into(),
-            "another-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
+    async fn test_syn_bad_cluster() {
+        let mut outsider_config = ChitchatConfig::for_test(2224);
+        let socket = UdpSocket::bind(outsider_config.listen_addr).await.unwrap();
+        outsider_config.cluster_id = "another-cluster".to_string();
+        let mut outsider =
+            Chitchat::with_node_id_and_seeds(outsider_config, empty_seeds(), Vec::new());
 
-        let server_addr = "0.0.0.0:2223";
-        let server = ChitchatServer::spawn(
-            server_addr.into(),
-            &[],
-            server_addr,
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
+        let server_config = ChitchatConfig::for_test(2223);
+        let server_addr = server_config.node_id.gossip_public_address;
+        let server = ChitchatServer::spawn(server_config, Vec::new()).await;
 
         let mut buf = Vec::new();
         let syn = outsider.create_syn_message();
@@ -481,31 +523,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ignore_broken_payload() {
-        let server_addr = "0.0.0.0:3331";
-        let server = ChitchatServer::spawn(
-            server_addr.into(),
-            &[],
-            server_addr,
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
-        let socket = UdpSocket::bind("0.0.0.0:3332").await.unwrap();
-        let mut chitchat = Chitchat::with_node_id_and_seeds(
-            "offline".into(),
-            HashSet::new(),
-            "offline".to_string(),
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
-
+    async fn test_ignore_broken_payload() {
+        let server_config = ChitchatConfig::for_test(3331);
+        let server_addr = server_config.node_id.gossip_public_address;
+        let server = ChitchatServer::spawn(server_config, Vec::new()).await;
+        let client_config = ChitchatConfig::for_test(3332);
+        let socket = UdpSocket::bind(client_config.listen_addr).await.unwrap();
+        let mut client_chitchat =
+            Chitchat::with_node_id_and_seeds(client_config, empty_seeds(), Vec::new());
         // Send broken payload.
         socket.send_to(b"broken", server_addr).await.unwrap();
 
         // Confirm nothing broke using a regular payload.
-        let syn = chitchat.create_syn_message();
+        let syn = client_chitchat.create_syn_message();
         let message = syn.serialize_to_vec();
         socket.send_to(&message, server_addr).await.unwrap();
 
@@ -522,18 +552,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn seeding() {
-        let server_addr = "0.0.0.0:5551";
-        let socket = UdpSocket::bind(server_addr).await.unwrap();
+    async fn test_seeding() {
+        let seed_config = ChitchatConfig::for_test(5551);
+        let seed_addr = seed_config.node_id.gossip_public_address;
+        let socket = UdpSocket::bind(seed_addr).await.unwrap();
 
-        let server = ChitchatServer::spawn(
-            "0.0.0.0:5552".into(),
-            &[server_addr.into()],
-            "0.0.0.0:5552",
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
+        let mut client_config = ChitchatConfig::for_test(5552);
+        client_config.seed_nodes = vec![seed_addr.to_string()];
+        let client = ChitchatServer::spawn(client_config, Vec::new()).await;
 
         let mut buf = [0; UDP_MTU];
         let (len, _addr) = timeout(socket.recv_from(&mut buf)).await.unwrap();
@@ -543,32 +569,20 @@ mod tests {
             message => panic!("unexpected message: {:?}", message),
         }
 
-        server.shutdown().await.unwrap();
+        client.shutdown().await.unwrap();
     }
 
     #[tokio::test]
-    async fn heartbeat() {
-        let test_addr = "0.0.0.0:6661";
-        let mut chitchat = Chitchat::with_node_id_and_seeds(
-            test_addr.into(),
-            HashSet::new(),
-            test_addr.to_string(),
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
+    async fn test_heartbeat() {
+        let test_config = ChitchatConfig::for_test(6661);
+        let test_addr = test_config.listen_addr;
+        let mut chitchat = Chitchat::with_node_id_and_seeds(test_config, empty_seeds(), Vec::new());
         let socket = UdpSocket::bind(test_addr).await.unwrap();
 
-        let server_addr = "0.0.0.0:6662";
-        let server_node_id = NodeId::from(server_addr);
-        let server = ChitchatServer::spawn(
-            NodeId::from(server_addr),
-            &[],
-            server_addr,
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
+        let server_config = ChitchatConfig::for_test(6662);
+        let server_id = server_config.node_id.clone();
+        let server_addr = server_config.node_id.gossip_public_address;
+        let server = ChitchatServer::spawn(server_config, Vec::new()).await;
 
         // Add our test socket to the server's nodes.
         server
@@ -600,7 +614,7 @@ mod tests {
             message => panic!("unexpected message: {:?}", message),
         };
 
-        let node_delta = &delta.node_deltas.get(&server_node_id).unwrap().key_values;
+        let node_delta = &delta.node_deltas.get(&server_id).unwrap().key_values;
         let heartbeat = &node_delta.get(HEARTBEAT_KEY).unwrap().value;
         assert_eq!(heartbeat, "2");
 
@@ -609,22 +623,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_member_change_event_is_broadcasted() {
-        let node1 = ChitchatServer::spawn(
-            NodeId::from("0.0.0.0:6663"),
-            &[],
-            "0.0.0.0:6663",
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
-        let node2 = ChitchatServer::spawn(
-            NodeId::from("0.0.0.0:6664"),
-            &["0.0.0.0:6663".to_string()],
-            "0.0.0.0:6664",
-            "test-cluster".to_string(),
-            Vec::<(&str, &str)>::new(),
-            FailureDetectorConfig::default(),
-        );
+        let node1_config = ChitchatConfig::for_test(6663);
+        let node1_addr = node1_config.node_id.gossip_public_address;
+        let node1 = ChitchatServer::spawn(node1_config, Vec::new()).await;
+
+        let mut node2_config = ChitchatConfig::for_test(6664);
+        node2_config.seed_nodes = vec![node1_addr.to_string()];
+        let node2_id = node2_config.node_id.clone();
+        let node2 = ChitchatServer::spawn(node2_config, Vec::new()).await;
         let mut live_nodes_watcher = node1
             .chitchat()
             .lock()
@@ -635,7 +641,7 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(3), async move {
             let live_nodes = live_nodes_watcher.next().await.unwrap();
             assert_eq!(live_nodes.len(), 1);
-            assert!(live_nodes.contains(&NodeId::from("0.0.0.0:6664")));
+            assert!(live_nodes.contains(&node2_id));
         })
         .await
         .unwrap();
@@ -646,49 +652,68 @@ mod tests {
 
     #[test]
     fn test_select_nodes_for_gossip() {
-        {
-            let mut rng = RngForTest::default();
-            let (nodes, dead_node, seed_node) = select_nodes_for_gossip(
-                &mut rng,
-                to_hash_set(&["node-1", "node-2", "node-3"]),
-                to_hash_set(&["node-1", "node-2"]),
-                to_hash_set(&["node-3"]),
-                to_hash_set(&["node-2"]),
-            );
-            assert_eq!(nodes.len(), 2);
-            assert_eq!(dead_node, Some("node-3".to_string()));
-            assert_eq!(
-                seed_node, None,
-                "Should have already gossiped with a seed node."
-            );
-        }
+        let node1 = NodeId::for_test_localhost(10_001);
+        let node2 = NodeId::for_test_localhost(10_002);
+        let node3 = NodeId::for_test_localhost(10_003);
+        let mut rng = RngForTest::default();
+        let (nodes, dead_node, seed_node) = select_nodes_for_gossip(
+            &mut rng,
+            to_hash_set(vec![
+                node1.gossip_public_address,
+                node2.gossip_public_address,
+                node3.gossip_public_address,
+            ]),
+            to_hash_set(vec![
+                node1.gossip_public_address,
+                node2.gossip_public_address,
+            ]),
+            to_hash_set(vec![node3.gossip_public_address]),
+            to_hash_set(vec![node2.gossip_public_address]),
+        );
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(dead_node, Some(node3.gossip_public_address));
+        assert_eq!(
+            seed_node, None,
+            "Should have already gossiped with a seed node."
+        );
+    }
 
-        {
-            let mut rng = RngForTest::default();
-            let (nodes, dead_node, seed_node) = select_nodes_for_gossip(
-                &mut rng,
-                to_hash_set(&["node-1", "node-2", "node-3", "node-4", "node-5"]),
-                to_hash_set(&["node-1", "node-2", "node-3", "node-4", "node-5"]),
-                to_hash_set(&[]),
-                to_hash_set(&[]),
-            );
-            assert_eq!(nodes.len(), 3);
-            assert_eq!(dead_node, None);
-            assert_eq!(seed_node, None);
-        }
+    #[test]
+    fn test_gossip_no_dead_node_no_seed_nodes() {
+        let nodes: HashSet<SocketAddr> = (10_001..=10_005)
+            .map(NodeId::for_test_localhost)
+            .map(|node_id| node_id.gossip_public_address)
+            .collect();
+        let mut rng = RngForTest::default();
+        let (nodes, dead_node, seed_node) = select_nodes_for_gossip(
+            &mut rng,
+            nodes.clone(),
+            nodes,
+            to_hash_set(vec![]),
+            to_hash_set(vec![]),
+        );
+        assert_eq!(nodes.len(), 3);
+        assert_eq!(dead_node, None);
+        assert_eq!(seed_node, None);
+    }
 
-        {
-            let mut rng = RngForTest::default();
-            let (nodes, dead_node, seed_node) = select_nodes_for_gossip(
-                &mut rng,
-                to_hash_set(&["node-1", "node-2", "node-3", "node-4", "node-5"]),
-                to_hash_set(&["node-1"]),
-                to_hash_set(&["node-2", "node-3", "node-4", "node-5"]),
-                to_hash_set(&["node-4", "node-5"]),
-            );
-            assert_eq!(nodes, ["node-1".to_string()]);
-            assert!(dead_node.is_some());
-            assert!(seed_node.is_some());
-        }
+    #[test]
+    fn test_gossip_dead_and_seed_node() {
+        let nodes: Vec<SocketAddr> = (10_001..=10_005)
+            .map(NodeId::for_test_localhost)
+            .map(|node_id| node_id.gossip_public_address)
+            .collect();
+        let seeds: HashSet<SocketAddr> = nodes[3..5].iter().cloned().collect();
+        let mut rng = RngForTest::default();
+        let (gossip_nodes, gossip_dead_node, gossip_seed_node) = select_nodes_for_gossip(
+            &mut rng,
+            to_hash_set(nodes.clone()),
+            to_hash_set(vec![nodes[0]]),
+            nodes[1..].iter().cloned().collect(),
+            seeds,
+        );
+        assert_eq!(gossip_nodes, &[nodes[0]]);
+        assert!(gossip_dead_node.is_some());
+        assert!(gossip_seed_node.is_some());
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -8,7 +8,6 @@ comment_width = 120
 format_strings = true
 group_imports = "StdExternalCrate"
 imports_granularity = "Module"
-license_template_path = ".license_header.txt"
 normalize_comments = true
 where_single_line = true
 wrap_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,8 +1,4 @@
-ignore = [
-  "quickwit-proto/src/cluster.rs",
-  "quickwit-proto/src/quickwit.rs",
-  "quickwit-swim",
-]
+ignore = []
 
 comment_width = 120
 format_strings = true


### PR DESCRIPTION
# Removed the use of string everywhere for addresses

The string were hiding several bugs.
This PR partially addresses it.

Before this PR, all addresses were `String`, that were
eventually resolved via `ToSocketAddrs`.

There are several cons and one bug associated with this approach.
Readability was hurt and API contract enforcing was a bit broken.
For instance, a user could have supplied an unresolved hostname as a gossip address.
As a result, all calls to that node would have triggered a DNS request. 

In addition, the logic that checks for peers to gossip with takes contains
some logic that relies on equality. For instance, we check if no seed was
already picked, before artificially adding a seed candidate.

That logic is broken, because the seed addrs are likely to be unresolved names
while peer address are likely to be socket addresses.

We switched all address to socket address except seeds.
Supplying a hostname as a socket addr is something that is very useful for k8s
for instance.

Internally, we just do slow polling over the name resolution of this seed hostname
to detect eventual new seed servers.

# Added node_id, public_addr option in chitchat test program

# simplified subprocess kill logic in unit test

Rather than registering a panic handler, and using a global, we rely on Drop.

# Seeding the random generator with the thread local generator (itself has been seed using system entropy).
This might help speed up the unit test a little bit.