### PR TITLE
Adding a transport abstraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
         name: cargo test
         with:
           command: test
-          args: -- --test-threads 1
+          args: --release -- --test-threads 1

--- a/chitchat/Cargo.toml
+++ b/chitchat/Cargo.toml
@@ -17,7 +17,9 @@ tokio = { version = "1.14.0", features = ["net", "sync", "rt-multi-thread", "mac
 tokio-stream = { version = "0.1", features = [ "sync" ] }
 anyhow = "1.0.51"
 tracing = "0.1"
+async-trait = "0.1"
 
 [dev-dependencies]
 assert-json-diff = "2"
 mock_instant = "0.2.1"
+tracing-subscriber = "0.3"

--- a/chitchat/src/failure_detector.rs
+++ b/chitchat/src/failure_detector.rs
@@ -180,7 +180,6 @@ impl SamplingWindow {
     pub fn phi(&self) -> f64 {
         // Ensure we don't call before any sample arrival.
         assert!(self.intervals.mean() > 0.0 && self.last_heartbeat.is_some());
-
         let elapsed_time = self.last_heartbeat.unwrap().elapsed().as_secs_f64();
         elapsed_time / self.intervals.mean()
     }

--- a/chitchat/src/transport/channel.rs
+++ b/chitchat/src/transport/channel.rs
@@ -1,0 +1,110 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use anyhow::{bail, Context};
+use async_trait::async_trait;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::{debug, info};
+
+use crate::serialize::Serializable;
+use crate::transport::{Socket, Transport};
+use crate::ChitchatMessage;
+
+const MAX_MESSAGE_PER_CHANNEL: usize = 100;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Statistics {
+    pub cumulated_num_bytes: u64,
+    pub num_messages: u64,
+}
+
+impl Statistics {
+    pub fn record_message_len(&mut self, message_num_bytes: usize) {
+        self.num_messages += 1;
+        self.cumulated_num_bytes += message_num_bytes as u64;
+    }
+}
+
+#[derive(Default)]
+struct ChannelTransportInner {
+    send_channels: HashMap<SocketAddr, Sender<(SocketAddr, ChitchatMessage)>>,
+    statistics: Statistics,
+}
+
+#[derive(Clone, Default)]
+pub struct ChannelTransport {
+    inner: Arc<Mutex<ChannelTransportInner>>,
+}
+
+#[async_trait]
+impl Transport for ChannelTransport {
+    async fn open(&self, listen_addr: SocketAddr) -> anyhow::Result<Box<dyn Socket>> {
+        let mut inner_lock = self.inner.lock().unwrap();
+        let (message_tx, message_rx) = tokio::sync::mpsc::channel(MAX_MESSAGE_PER_CHANNEL);
+        if inner_lock.send_channels.contains_key(&listen_addr) {
+            bail!("Address not available `{listen_addr}`");
+        }
+        inner_lock.send_channels.insert(listen_addr, message_tx);
+        Ok(Box::new(InProcessSocket {
+            listen_addr,
+            broker: self.clone(),
+            message_rx,
+        }))
+    }
+}
+
+impl ChannelTransport {
+    pub fn statistics(&self) -> Statistics {
+        self.inner.lock().unwrap().statistics
+    }
+
+    fn close(&self, addr: SocketAddr) {
+        info!(addr=%addr, "close");
+        let mut inner_lock = self.inner.lock().unwrap();
+        inner_lock.send_channels.remove(&addr);
+    }
+
+    async fn send(
+        &self,
+        from_addr: SocketAddr,
+        to_addr: SocketAddr,
+        message: ChitchatMessage,
+    ) -> anyhow::Result<()> {
+        let num_bytes = message.serialized_len();
+        debug!(num_bytes = num_bytes, "send");
+        let mut inner_lock = self.inner.lock().unwrap();
+        inner_lock.statistics.record_message_len(num_bytes);
+        if let Some(message_tx) = inner_lock.send_channels.get(&to_addr) {
+            // if the channel is saturated, we start dropping messages.
+            let _ = message_tx.try_send((from_addr, message));
+        }
+        Ok(())
+    }
+}
+
+struct InProcessSocket {
+    listen_addr: SocketAddr,
+    broker: ChannelTransport,
+    message_rx: Receiver<(SocketAddr, ChitchatMessage)>,
+}
+
+#[async_trait]
+impl Socket for InProcessSocket {
+    async fn send(&mut self, to_addr: SocketAddr, message: ChitchatMessage) -> anyhow::Result<()> {
+        self.broker.send(self.listen_addr, to_addr, message).await?;
+        Ok(())
+    }
+
+    /// Recv needs to be cancellable.
+    async fn recv(&mut self) -> anyhow::Result<(SocketAddr, ChitchatMessage)> {
+        let (from_addr, message) = self.message_rx.recv().await.context("Channel closed")?;
+        Ok((from_addr, message))
+    }
+}
+
+impl Drop for InProcessSocket {
+    fn drop(&mut self) {
+        self.broker.close(self.listen_addr);
+    }
+}

--- a/chitchat/src/transport/mod.rs
+++ b/chitchat/src/transport/mod.rs
@@ -1,0 +1,126 @@
+use std::net::SocketAddr;
+
+use async_trait::async_trait;
+
+use crate::message::ChitchatMessage;
+
+mod channel;
+mod udp;
+mod utils;
+
+pub use channel::{ChannelTransport, Statistics};
+pub use udp::UdpTransport;
+pub use utils::TransportExt;
+
+#[async_trait]
+pub trait Transport: Send + Sync + 'static {
+    async fn open(&self, listen_addr: SocketAddr) -> anyhow::Result<Box<dyn Socket>>;
+}
+
+#[async_trait]
+pub trait Socket: Send + Sync + 'static {
+    // Only returns an error if the transport is broken and may not emit message
+    // in the future.
+    async fn send(&mut self, to: SocketAddr, msg: ChitchatMessage) -> anyhow::Result<()>;
+    // Only returns an error if the transport is broken and may not receive message
+    // in the future.
+    async fn recv(&mut self) -> anyhow::Result<(SocketAddr, ChitchatMessage)>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+    use std::time::Duration;
+
+    use tokio::net::UdpSocket;
+    use tokio::time::timeout;
+
+    use super::Transport;
+    use crate::digest::Digest;
+    use crate::message::ChitchatMessage;
+    use crate::serialize::Serializable;
+    use crate::transport::{ChannelTransport, UdpTransport};
+
+    fn sample_syn_msg() -> ChitchatMessage {
+        ChitchatMessage::Syn {
+            cluster_id: "cluster_id".to_string(),
+            digest: Digest::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_udp_transport_ignore_invalid_payload() {
+        let recv_addr: SocketAddr = ([127, 0, 0, 1], 30_000u16).into();
+        let send_addr: SocketAddr = ([127, 0, 0, 1], 30_001u16).into();
+        let send_udp_socket: UdpSocket = UdpSocket::bind(send_addr).await.unwrap();
+        let mut recv_socket = UdpTransport.open(recv_addr).await.unwrap();
+        let invalid_payload = b"junk";
+        send_udp_socket
+            .send_to(&invalid_payload[..], recv_addr)
+            .await
+            .unwrap();
+        let valid_message = sample_syn_msg();
+        let mut valid_payload: Vec<u8> = Vec::new();
+        valid_message.serialize(&mut valid_payload);
+        send_udp_socket
+            .send_to(&valid_payload[..], recv_addr)
+            .await
+            .unwrap();
+        let (send_addr2, received_message) = recv_socket.recv().await.unwrap();
+        assert_eq!(send_addr, send_addr2);
+        assert_eq!(received_message, valid_message);
+    }
+
+    async fn test_transport_cannot_open_twice_aux(transport: &dyn Transport) {
+        let addr: SocketAddr = ([127, 0, 0, 1], 10_000u16).into();
+        let _socket = transport.open(addr).await.unwrap();
+        assert!(transport.open(addr).await.is_err());
+    }
+
+    async fn test_transport_recv_waits_for_message(transport: &dyn Transport) {
+        let addr1: SocketAddr = ([127, 0, 0, 1], 20_001u16).into();
+        let addr2: SocketAddr = ([127, 0, 0, 1], 20_002u16).into();
+        let mut socket1 = transport.open(addr1).await.unwrap();
+        let mut socket2 = transport.open(addr2).await.unwrap();
+        assert!(timeout(Duration::from_millis(200), socket2.recv())
+            .await
+            .is_err());
+        let syn_message = sample_syn_msg();
+        let socket_recv_fut = tokio::task::spawn(async move { socket2.recv().await.unwrap() });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        socket1.send(addr2, syn_message).await.unwrap();
+        let (exp1, _received_msg) = socket_recv_fut.await.unwrap();
+        assert_eq!(addr1, exp1);
+    }
+
+    async fn test_transport_socket_released_on_drop(transport: &dyn Transport) {
+        let addr: SocketAddr = ([127, 0, 0, 1], 10_000u16).into();
+        let socket = transport.open(addr).await.unwrap();
+        std::mem::drop(socket);
+        let _new_socket = transport.open(addr).await.unwrap();
+    }
+
+    async fn test_transport_sending_to_unbound_addr_is_ok(transport: &dyn Transport) {
+        let addr: SocketAddr = ([127, 0, 0, 1], 40_000u16).into();
+        let unbound_addr: SocketAddr = ([127, 0, 0, 1], 40_001u16).into();
+        let mut socket = transport.open(addr).await.unwrap();
+        socket.send(unbound_addr, sample_syn_msg()).await.unwrap()
+    }
+
+    async fn test_transport_suite(transport: &dyn Transport) {
+        test_transport_cannot_open_twice_aux(transport).await;
+        test_transport_socket_released_on_drop(transport).await;
+        test_transport_recv_waits_for_message(transport).await;
+        test_transport_sending_to_unbound_addr_is_ok(transport).await;
+    }
+
+    #[tokio::test]
+    async fn test_transport_udp() {
+        test_transport_suite(&UdpTransport).await;
+    }
+
+    #[tokio::test]
+    async fn test_transport_in_mem() {
+        test_transport_suite(&ChannelTransport::default()).await;
+    }
+}

--- a/chitchat/src/transport/udp.rs
+++ b/chitchat/src/transport/udp.rs
@@ -1,0 +1,87 @@
+use std::net::SocketAddr;
+
+use anyhow::{bail, Context};
+use async_trait::async_trait;
+use tracing::warn;
+
+use crate::serialize::Serializable;
+use crate::transport::{Socket, Transport};
+use crate::ChitchatMessage;
+
+/// Maximum payload size (in bytes) for UDP.
+const UDP_MTU: usize = 1_400;
+
+pub struct UdpTransport;
+
+#[async_trait]
+impl Transport for UdpTransport {
+    async fn open(&self, bind_addr: SocketAddr) -> anyhow::Result<Box<dyn Socket>> {
+        let socket = tokio::net::UdpSocket::bind(bind_addr)
+            .await
+            .with_context(|| format!("Failed to bind to {bind_addr}/UDP for gossip."))?;
+        Ok(Box::new(UdpSocket {
+            buf_send: Vec::with_capacity(UDP_MTU),
+            buf_recv: Box::new([0u8; UDP_MTU]),
+            socket,
+        }))
+    }
+}
+
+struct UdpSocket {
+    buf_send: Vec<u8>,
+    buf_recv: Box<[u8; UDP_MTU]>,
+    socket: tokio::net::UdpSocket,
+}
+
+#[async_trait]
+impl Socket for UdpSocket {
+    async fn send(&mut self, to_addr: SocketAddr, message: ChitchatMessage) -> anyhow::Result<()> {
+        self.buf_send.clear();
+        message.serialize(&mut self.buf_send);
+        let buf_send_len = self.buf_send.len();
+        if buf_send_len > UDP_MTU {
+            bail!("Message larger ({buf_send_len} bytes) than mtu ({UDP_MTU} bytes)");
+        }
+        self.send_bytes(to_addr, &self.buf_send).await?;
+        Ok(())
+    }
+
+    /// Recv needs to be cancellable.
+    async fn recv(&mut self) -> anyhow::Result<(SocketAddr, ChitchatMessage)> {
+        loop {
+            if let Some(message) = self.receive_one().await? {
+                return Ok(message);
+            }
+        }
+    }
+}
+
+impl UdpSocket {
+    async fn receive_one(&mut self) -> anyhow::Result<Option<(SocketAddr, ChitchatMessage)>> {
+        let (len, from_addr) = self
+            .socket
+            .recv_from(&mut self.buf_recv[..])
+            .await
+            .context("Error while receiving UDP message")?;
+        let mut buf = &self.buf_recv[..len];
+        match ChitchatMessage::deserialize(&mut buf) {
+            Ok(msg) => Ok(Some((from_addr, msg))),
+            Err(err) => {
+                warn!(payload_len=len, from=%from_addr, err=%err, "invalid-chitchat-payload");
+                Ok(None)
+            }
+        }
+    }
+
+    pub(crate) async fn send_bytes(
+        &self,
+        to_addr: SocketAddr,
+        payload: &[u8],
+    ) -> anyhow::Result<()> {
+        self.socket
+            .send_to(payload, to_addr)
+            .await
+            .context("Failed to send chitchat message to target")?;
+        Ok(())
+    }
+}

--- a/chitchat/src/transport/utils.rs
+++ b/chitchat/src/transport/utils.rs
@@ -1,0 +1,116 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rand::distributions::Bernoulli;
+use rand::prelude::{Distribution, SmallRng};
+use rand::{thread_rng, SeedableRng};
+use tokio::sync::RwLock;
+
+use crate::transport::{Socket, Transport};
+use crate::ChitchatMessage;
+
+struct TransportWithDelay<D: Distribution<f32> + Send + Sync + 'static> {
+    delay_secs: D,
+    transport: Box<dyn Transport>,
+}
+
+pub trait DelayMillisDist: Distribution<f32> + Send + Sync + Clone + 'static {}
+
+#[async_trait]
+impl<D: DelayMillisDist> Transport for TransportWithDelay<D> {
+    async fn open(&self, listen_addr: SocketAddr) -> anyhow::Result<Box<dyn Socket>> {
+        let rng = SmallRng::from_rng(thread_rng()).unwrap();
+        let socket = self.transport.open(listen_addr).await?;
+        Ok(Box::new(SocketWithDelay {
+            delay_secs: self.delay_secs.clone(),
+            socket: Arc::new(RwLock::new(socket)),
+            rng,
+        }))
+    }
+}
+
+struct SocketWithDelay<D: Distribution<f32> + Send + Sync + 'static> {
+    delay_secs: D,
+    socket: Arc<RwLock<Box<dyn Socket>>>,
+    rng: SmallRng,
+}
+
+#[async_trait]
+impl<D: DelayMillisDist> Socket for SocketWithDelay<D> {
+    async fn send(&mut self, to: SocketAddr, message: ChitchatMessage) -> anyhow::Result<()> {
+        let socket_clone = self.socket.clone();
+        let delay_secs = self.delay_secs.sample(&mut self.rng);
+        let delay = Duration::from_secs_f32(delay_secs);
+        tokio::task::spawn(async move {
+            tokio::time::sleep(delay).await;
+            let _ = socket_clone.write().await.send(to, message).await;
+        });
+        Ok(())
+    }
+
+    async fn recv(&mut self) -> anyhow::Result<(SocketAddr, ChitchatMessage)> {
+        self.socket.write().await.recv().await
+    }
+}
+
+pub trait TransportExt {
+    fn drop_message(self, drop_probability: f64) -> Box<dyn Transport>;
+    fn delay<D: DelayMillisDist>(self, delay_proba: D) -> Box<dyn Transport>;
+}
+
+impl<T: Transport> TransportExt for T {
+    fn drop_message(self, drop_probability: f64) -> Box<dyn Transport> {
+        Box::new(TransportWithMessageDrop {
+            drop_probability: Bernoulli::new(drop_probability).unwrap(),
+            transport: Box::new(self),
+        })
+    }
+
+    fn delay<D: DelayMillisDist>(self, delay_secs: D) -> Box<dyn Transport> {
+        Box::new(TransportWithDelay {
+            delay_secs,
+            transport: Box::new(self),
+        })
+    }
+}
+
+struct TransportWithMessageDrop {
+    drop_probability: Bernoulli,
+    transport: Box<dyn Transport>,
+}
+
+#[async_trait]
+impl Transport for TransportWithMessageDrop {
+    async fn open(&self, listen_addr: SocketAddr) -> anyhow::Result<Box<dyn Socket>> {
+        let rng = SmallRng::from_rng(thread_rng()).unwrap();
+        let socket = self.transport.open(listen_addr).await?;
+        Ok(Box::new(SocketWithMessageDrop {
+            drop_probability: self.drop_probability,
+            socket,
+            rng,
+        }))
+    }
+}
+
+struct SocketWithMessageDrop {
+    drop_probability: Bernoulli,
+    socket: Box<dyn Socket>,
+    rng: SmallRng,
+}
+
+#[async_trait]
+impl Socket for SocketWithMessageDrop {
+    async fn send(&mut self, to: SocketAddr, message: ChitchatMessage) -> anyhow::Result<()> {
+        let should_drop = self.drop_probability.sample(&mut self.rng);
+        if should_drop {
+            return Ok(());
+        }
+        self.socket.send(to, message).await
+    }
+
+    async fn recv(&mut self) -> anyhow::Result<(SocketAddr, ChitchatMessage)> {
+        self.socket.recv().await
+    }
+}

--- a/chitchat/tests/perf_test.rs
+++ b/chitchat/tests/perf_test.rs
@@ -1,0 +1,196 @@
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use chitchat::transport::{ChannelTransport, Transport, TransportExt};
+use chitchat::{spawn_chitchat, ChitchatConfig, ChitchatHandle, FailureDetectorConfig, NodeId};
+use tokio::time::Instant;
+use tokio_stream::StreamExt;
+use tracing::info;
+
+async fn spawn_one(node_id: u16, transport: &dyn Transport) -> ChitchatHandle {
+    let listen_addr: SocketAddr = ([127, 0, 0, 1], 10_000u16 + node_id).into();
+    let node_id = NodeId {
+        id: format!("node_{node_id}"),
+        gossip_public_address: listen_addr,
+    };
+    let gossip_interval = Duration::from_millis(300);
+    let config = ChitchatConfig {
+        node_id,
+        cluster_id: "default-cluster".to_string(),
+        gossip_interval,
+        listen_addr,
+        seed_nodes: vec!["127.0.0.1:10000".to_string()],
+        mtu: 60_000,
+        failure_detector_config: FailureDetectorConfig {
+            initial_interval: gossip_interval,
+            ..Default::default()
+        },
+    };
+    spawn_chitchat(config, vec![], transport).await.unwrap()
+}
+
+async fn spawn_nodes(num_nodes: u16, transport: &dyn Transport) -> Vec<ChitchatHandle> {
+    let mut handles = Vec::new();
+    for node_id in 0..num_nodes {
+        let handle = spawn_one(node_id, transport).await;
+        handles.push(handle);
+    }
+    handles
+}
+
+async fn wait_until<P: Fn(&HashSet<NodeId>) -> bool>(
+    handle: &ChitchatHandle,
+    predicate: P,
+) -> Duration {
+    let start = Instant::now();
+    let mut node_watcher = handle.chitchat().lock().await.live_nodes_watcher();
+    while let Some(nodes) = node_watcher.next().await {
+        if predicate(&nodes) {
+            break;
+        }
+    }
+    start.elapsed()
+}
+
+async fn delay_before_detection_sample(num_nodes: usize, transport: &dyn Transport) -> Duration {
+    assert!(num_nodes > 2);
+    let mut handles = spawn_nodes(num_nodes as u16, transport).await;
+    info!("spawn {num_nodes} nodes");
+    let _delay = wait_until(&handles[1], |nodes| nodes.len() == num_nodes - 1).await;
+    info!("converged on {num_nodes} nodes");
+    let _delay = wait_until(&handles[1], |nodes| nodes.len() == num_nodes - 1).await;
+    handles.pop();
+    let time_to_death_detection =
+        wait_until(&handles[1], |nodes| nodes.len() == num_nodes - 2).await;
+    for handle in handles {
+        handle.shutdown().await.unwrap();
+    }
+    info!(time_to_death_detection=?time_to_death_detection);
+    time_to_death_detection
+}
+
+#[tokio::test]
+async fn test_delay_before_dead_detection_10() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let transport = ChannelTransport::default();
+    let delay = delay_before_detection_sample(40, &transport).await;
+    assert!(delay < Duration::from_secs(4));
+}
+
+#[tokio::test]
+async fn test_delay_before_dead_detection_20() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let transport = ChannelTransport::default();
+    let delay = delay_before_detection_sample(20, &transport).await;
+    assert!(delay < Duration::from_secs(4));
+}
+
+#[tokio::test]
+async fn test_delay_before_dead_detection_40() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let transport = ChannelTransport::default();
+    let delay = delay_before_detection_sample(40, &transport).await;
+    assert!(delay < Duration::from_secs(5));
+}
+
+#[tokio::test]
+async fn test_delay_before_dead_detection_100() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let transport = ChannelTransport::default();
+    let delay = delay_before_detection_sample(100, &transport).await;
+    assert!(delay < Duration::from_secs(5));
+}
+
+#[tokio::test]
+async fn test_delay_before_dead_detection_100_faulty() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let transport = ChannelTransport::default().drop_message(0.5f64);
+    let delay = delay_before_detection_sample(100, &*transport).await;
+    assert!(delay < Duration::from_secs(7));
+}
+
+async fn test_bandwidth_aux(num_nodes: usize) -> u64 {
+    let _ = tracing_subscriber::fmt::try_init();
+    assert!(num_nodes > 2);
+    let transport = ChannelTransport::default();
+    let handles = spawn_nodes(num_nodes as u16, &transport).await;
+    let instant = Instant::now();
+    for handle in &handles {
+        wait_until(handle, |nodes| nodes.len() == num_nodes - 1).await;
+        info!("success");
+    }
+    let cluster_convergence = instant.elapsed();
+    info!(cluster_convergence=?cluster_convergence);
+    const MEASUREMENT_FRAME_SECS: u64 = 3;
+    let stat_before = transport.statistics();
+    tokio::time::sleep(Duration::from_secs(MEASUREMENT_FRAME_SECS)).await;
+    let stat_after = transport.statistics();
+    let bytes_per_sec_per_node = (stat_after.cumulated_num_bytes - stat_before.cumulated_num_bytes)
+        / (num_nodes as u64 * MEASUREMENT_FRAME_SECS);
+    let num_messages_per_sec_per_node = (stat_after.num_messages - stat_before.num_messages)
+        / (num_nodes as u64 * MEASUREMENT_FRAME_SECS);
+    info!(num_messages_per_sec_per_node=num_messages_per_sec_per_node, bandwidth_per_node=%bytes_per_sec_per_node);
+    assert!(num_messages_per_sec_per_node < 50);
+    bytes_per_sec_per_node
+}
+
+#[tokio::test]
+async fn test_bandwidth_10() {
+    let _ = tracing_subscriber::fmt::try_init();
+    assert!(test_bandwidth_aux(10).await < 15_000);
+}
+
+#[tokio::test]
+async fn test_bandwidth_20() {
+    let _ = tracing_subscriber::fmt::try_init();
+    test_bandwidth_aux(20).await;
+    assert!(test_bandwidth_aux(20).await < 25_000);
+}
+
+#[tokio::test]
+async fn test_bandwidth_40() {
+    let _ = tracing_subscriber::fmt::try_init();
+    assert!(test_bandwidth_aux(40).await < 50_000);
+}
+
+#[tokio::test]
+async fn test_bandwidth_100() {
+    let _ = tracing_subscriber::fmt::try_init();
+    assert!(test_bandwidth_aux(100).await < 120_000);
+}
+
+async fn test_faulty_network_stability_aux(num_nodes: usize, transport: &dyn Transport) {
+    // 50% messages are dropped.
+    assert!(num_nodes > 2);
+    let handles = spawn_nodes(num_nodes as u16, transport).await;
+    let start = Instant::now();
+    for handle in &handles {
+        wait_until(handle, |nodes| nodes.len() == num_nodes - 1).await;
+    }
+    let elapsed = start.elapsed();
+    info!("Convergence took {elapsed:?}");
+    let lost_one_node = wait_until(&handles[1], |nodes| nodes.len() != num_nodes - 1);
+    // We want this to timeout!
+    tokio::time::timeout(Duration::from_secs(30), lost_one_node)
+        .await
+        .unwrap_err();
+}
+
+#[tokio::test]
+async fn test_faulty_network_stability_10() {
+    let _ = tracing_subscriber::fmt::try_init();
+    // 50% messages are dropped.
+    use chitchat::transport::TransportExt;
+    let transport: Box<dyn Transport> = ChannelTransport::default().drop_message(0.5f64);
+    test_faulty_network_stability_aux(10, &*transport).await;
+}
+
+#[tokio::test]
+async fn test_faulty_network_stability_100() {
+    let _ = tracing_subscriber::fmt::try_init();
+    // 50% messages are dropped.
+    use chitchat::transport::TransportExt;
+    let transport: Box<dyn Transport> = ChannelTransport::default().drop_message(0.5f64);
+    test_faulty_network_stability_aux(10, &*transport).await;
+}


### PR DESCRIPTION
This PR is adding a transport abstraction.

The point of this transport layer is:
-  to make it easy to simulate what happens if X% of the message are dropped, or if they are delayed.
- avoid having to juggle with UDP port allocation in unit test, and safely simulate 100 of nodes. 
- measure metrics such as the amount of data exchanged during simulations.
- slightly simplify the code of the server. 

This PR also:
Stops updating heartbeat on all ack messages.
While this was not hurting correctness, in the same round of gossip, we would send 3 different gossip to peers A,B,C. 
This would generate meaningless update messages within the cluster.

This PR also adds a lot of performance tests simulating chitchat and checking that it is behaving correctly.
