### PR TITLE
Refactor `NodeId`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ license-check:
 license-fix:
 	docker run -it --rm -v $(shell pwd):/github/workspace ghcr.io/apache/skywalking-eyes/license-eye header fix
 
+fix: fmt
+	@echo "Running cargo clippy --fix"
+	@cargo clippy --fix --all-features --allow-dirty --allow-staged
+
 fmt:
 	@echo "Formatting Rust files"
 	@(rustup toolchain list | ( ! grep -q nightly && echo "Toolchain 'nightly' is not installed. Please install using 'rustup toolchain install nightly'.") ) || cargo +nightly fmt

--- a/chitchat-test/src/lib.rs
+++ b/chitchat-test/src/lib.rs
@@ -1,15 +1,15 @@
-use chitchat::{ClusterStateSnapshot, NodeId};
+use chitchat::{ChitchatId, ClusterStateSnapshot};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ApiResponse {
     pub cluster_id: String,
     pub cluster_state: ClusterStateSnapshot,
-    pub live_nodes: Vec<NodeId>,
-    pub dead_nodes: Vec<NodeId>,
+    pub live_nodes: Vec<ChitchatId>,
+    pub dead_nodes: Vec<ChitchatId>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SetKeyValueResponse {
     pub status: bool,
 }

--- a/chitchat/Cargo.toml
+++ b/chitchat/Cargo.toml
@@ -10,14 +10,14 @@ repository = "https://github.com/quickwit-oss/chitchat"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.51"
+async-trait = "0.1"
 bytes = "1"
 rand = { version = "0.8", features = ["small_rng"] }
-serde = { version="1", features=["derive"] }
+serde = { version = "1", features = ["derive"] }
 tokio = { version = "1.14.0", features = ["net", "sync", "rt-multi-thread", "macros", "time"] }
-tokio-stream = { version = "0.1", features = [ "sync" ] }
-anyhow = "1.0.51"
+tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
-async-trait = "0.1"
 
 [dev-dependencies]
 assert-json-diff = "2"

--- a/chitchat/src/digest.rs
+++ b/chitchat/src/digest.rs
@@ -1,21 +1,21 @@
 use std::collections::BTreeMap;
 
 use crate::serialize::*;
-use crate::{NodeId, Version};
+use crate::{ChitchatId, Version};
 
 /// A digest represents is a piece of information summarizing
 /// the staleness of one peer's data.
 ///
 /// It is equivalent to a map
 /// peer -> max version.
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct Digest {
-    pub(crate) node_max_version: BTreeMap<NodeId, Version>,
+    pub(crate) node_max_version: BTreeMap<ChitchatId, Version>,
 }
 
 impl Digest {
     #[cfg(test)]
-    pub fn add_node(&mut self, node: NodeId, max_version: Version) {
+    pub fn add_node(&mut self, node: ChitchatId, max_version: Version) {
         self.node_max_version.insert(node, max_version);
     }
 }
@@ -23,27 +23,27 @@ impl Digest {
 impl Serializable for Digest {
     fn serialize(&self, buf: &mut Vec<u8>) {
         (self.node_max_version.len() as u16).serialize(buf);
-        for (node_id, version) in &self.node_max_version {
-            node_id.serialize(buf);
+        for (chitchat_id, version) in &self.node_max_version {
+            chitchat_id.serialize(buf);
             version.serialize(buf);
         }
     }
 
     fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
         let num_nodes = u16::deserialize(buf)?;
-        let mut node_max_version: BTreeMap<NodeId, Version> = Default::default();
+        let mut node_max_version: BTreeMap<ChitchatId, Version> = Default::default();
         for _ in 0..num_nodes {
-            let node_id = NodeId::deserialize(buf)?;
+            let chitchat_id = ChitchatId::deserialize(buf)?;
             let version = u64::deserialize(buf)?;
-            node_max_version.insert(node_id, version);
+            node_max_version.insert(chitchat_id, version);
         }
         Ok(Digest { node_max_version })
     }
 
     fn serialized_len(&self) -> usize {
         let mut len = (self.node_max_version.len() as u16).serialized_len();
-        for (node_id, version) in &self.node_max_version {
-            len += node_id.serialized_len();
+        for (chitchat_id, version) in &self.node_max_version {
+            len += chitchat_id.serialized_len();
             len += version.serialized_len();
         }
         len

--- a/chitchat/src/message.rs
+++ b/chitchat/src/message.rs
@@ -12,7 +12,7 @@ use crate::serialize::Serializable;
 /// between node A and node B.
 /// The names {Syn, SynAck, Ack} of the different steps are borrowed from
 /// TCP Handshake.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ChitchatMessage {
     /// Node A initiates handshakes.
     Syn { cluster_id: String, digest: Digest },
@@ -119,18 +119,18 @@ pub(crate) fn syn_ack_serialized_len(digest: &Digest, delta: &Delta) -> usize {
 #[cfg(test)]
 mod tests {
     use crate::serialize::test_serdeser_aux;
-    use crate::{ChitchatMessage, Digest, NodeId};
+    use crate::{ChitchatId, ChitchatMessage, Digest};
 
     #[test]
     fn test_syn() {
         let mut digest = Digest::default();
-        digest.add_node(NodeId::for_test_localhost(10_001), 1);
-        digest.add_node(NodeId::for_test_localhost(10_002), 2);
+        digest.add_node(ChitchatId::for_local_test(10_001), 1);
+        digest.add_node(ChitchatId::for_local_test(10_002), 2);
         let syn = ChitchatMessage::Syn {
             cluster_id: "cluster-a".to_string(),
             digest,
         };
-        test_serdeser_aux(&syn, 68);
+        test_serdeser_aux(&syn, 84);
     }
 
     #[test]

--- a/chitchat/tests/cluster_test.rs
+++ b/chitchat/tests/cluster_test.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::anyhow;
 use chitchat::transport::ChannelTransport;
 use chitchat::{
-    spawn_chitchat, ChitchatConfig, ChitchatHandle, FailureDetectorConfig, NodeId, NodeState,
+    spawn_chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig, NodeState,
 };
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
@@ -13,23 +13,23 @@ use tracing::{debug, info};
 
 enum Operation {
     InsertKeysValues {
-        node_id: NodeId,
+        chitchat_id: ChitchatId,
         keys_values: Vec<(String, String)>,
     },
     MarkKeyForDeletion {
-        node_id: NodeId,
+        chitchat_id: ChitchatId,
         key: String,
     },
     AddNode {
-        node_id: NodeId,
-        peer_seeds: Option<Vec<NodeId>>,
+        chitchat_id: ChitchatId,
+        peer_seeds: Option<Vec<ChitchatId>>,
     },
-    RemoveNetworkLink(NodeId, NodeId),
-    AddNetworkLink(NodeId, NodeId),
+    RemoveNetworkLink(ChitchatId, ChitchatId),
+    AddNetworkLink(ChitchatId, ChitchatId),
     Wait(Duration),
     NodeStateAssert {
-        server_node_id: NodeId,
-        node_id: NodeId,
+        server_chitchat_id: ChitchatId,
+        chitchat_id: ChitchatId,
         predicate: NodeStatePredicate,
         timeout_opt: Option<Duration>,
     },
@@ -64,7 +64,7 @@ impl NodeStatePredicate {
 
 struct Simulator {
     transport: ChannelTransport,
-    node_handles: HashMap<NodeId, ChitchatHandle>,
+    node_handles: HashMap<ChitchatId, ChitchatHandle>,
     gossip_interval: Duration,
     marked_for_deletion_key_grace_period: usize,
 }
@@ -83,75 +83,85 @@ impl Simulator {
         for operation in operations.into_iter() {
             match operation {
                 Operation::AddNode {
-                    node_id,
+                    chitchat_id,
                     peer_seeds,
                 } => {
-                    self.spawn_node(node_id, peer_seeds).await;
+                    self.spawn_node(chitchat_id, peer_seeds).await;
                 }
                 Operation::InsertKeysValues {
-                    node_id,
+                    chitchat_id,
                     keys_values,
                 } => {
-                    self.insert_keys_values(node_id, keys_values).await;
+                    self.insert_keys_values(chitchat_id, keys_values).await;
                 }
-                Operation::MarkKeyForDeletion { node_id, key } => {
-                    self.mark_for_deletion(node_id, key).await;
+                Operation::MarkKeyForDeletion { chitchat_id, key } => {
+                    self.mark_for_deletion(chitchat_id, key).await;
                 }
                 Operation::Wait(duration) => {
                     tokio::time::sleep(duration).await;
                 }
                 Operation::RemoveNetworkLink(node_1, node_2) => {
-                    info!(node_l=%node_1.id, node_r=%node_2.id, "remove-link");
+                    info!(node_l=%node_1.node_id, node_r=%node_2.node_id, "remove-link");
                     self.transport
-                        .remove_link(node_1.gossip_public_address, node_2.gossip_public_address)
+                        .remove_link(
+                            node_1.gossip_advertise_address,
+                            node_2.gossip_advertise_address,
+                        )
                         .await;
                 }
                 Operation::AddNetworkLink(node_1, node_2) => {
-                    debug!(node_l=%node_1.id, node_r=%node_2.id, "add-link");
+                    debug!(node_l=%node_1.node_id, node_r=%node_2.node_id, "add-link");
                     self.transport
-                        .add_link(node_1.gossip_public_address, node_2.gossip_public_address)
+                        .add_link(
+                            node_1.gossip_advertise_address,
+                            node_2.gossip_advertise_address,
+                        )
                         .await;
                 }
                 Operation::NodeStateAssert {
-                    server_node_id,
-                    node_id,
+                    server_chitchat_id,
+                    chitchat_id,
                     predicate,
                     timeout_opt,
                 } => {
-                    info!(server_node_id=%server_node_id.id, node_id=%node_id.id, "node-state-assert");
-                    let chitchat = self.node_handles.get(&server_node_id).unwrap().chitchat();
+                    info!(server_node_id=%server_chitchat_id.node_id, node_id=%chitchat_id.node_id, "node-state-assert");
+                    let chitchat = self
+                        .node_handles
+                        .get(&server_chitchat_id)
+                        .unwrap()
+                        .chitchat();
                     // Wait for node_state & predicate.
                     if let Some(timeout) = timeout_opt {
                         let chitchat_clone = chitchat.clone();
-                        let node_id_clone = node_id.clone();
+                        let chitchat_id_clone = chitchat_id.clone();
                         tokio::time::timeout(timeout, async move {
                             loop {
                                 let chitchat_guard = chitchat_clone.lock().await;
-                                if let Some(node_state) = chitchat_guard.node_state(&node_id_clone) {
+                                if let Some(node_state) = chitchat_guard.node_state(&chitchat_id_clone) {
                                     if predicate.check(node_state) {
                                         break;
                                     } else {
-                                        info!(node_id=%node_id_clone.id, "Waiting for predicate to be true.");
+                                        info!(node_id=%chitchat_id_clone.node_id, "Waiting for predicate to be true.");
                                     }
                                 } else {
-                                    info!(node_id=%node_id_clone.id, "Waiting for node state to be present.");
+                                    info!(node_id=%chitchat_id_clone.node_id, "Waiting for node state to be present.");
                                 }
                                 drop(chitchat_guard);
                                 tokio::time::sleep(Duration::from_millis(100)).await;
                             }
                         }).await.map_err(|_| {
-                            anyhow!("Predicate timeout on node_id={}", node_id.id)
+                            anyhow!("Predicate timeout on chitchat_id={}", chitchat_id.node_id)
                         }).unwrap();
                     } else {
                         let chitchat_guard = chitchat.lock().await;
-                        if let Some(node_state) = chitchat_guard.node_state(&node_id) {
+                        if let Some(node_state) = chitchat_guard.node_state(&chitchat_id) {
                             let predicate_value = predicate.check(node_state);
                             if !predicate_value {
-                                info!(node_id=?node_id.id, state_snapshot=?chitchat_guard.state_snapshot(), "Predicate false.");
+                                info!(node_id=%chitchat_id.node_id, state_snapshot=?chitchat_guard.state_snapshot(), "Predicate false.");
                             }
                             assert!(predicate_value);
                         } else {
-                            info!(node_id=?node_id.id, state_snapshot=?chitchat_guard.state_snapshot(), "Node state missing.");
+                            info!(node_id=%chitchat_id.node_id, state_snapshot=?chitchat_guard.state_snapshot(), "Node state missing.");
                             panic!("Node state missing");
                         }
                     }
@@ -162,20 +172,20 @@ impl Simulator {
 
     pub async fn insert_keys_values(
         &mut self,
-        node_id: NodeId,
+        chitchat_id: ChitchatId,
         keys_values: Vec<(String, String)>,
     ) {
-        info!(node_id=%node_id.id, num_keys_values=?keys_values.len(), "insert-keys-values");
-        let chitchat = self.node_handles.get(&node_id).unwrap().chitchat();
+        info!(node_id=%chitchat_id.node_id, num_keys_values=?keys_values.len(), "insert-keys-values");
+        let chitchat = self.node_handles.get(&chitchat_id).unwrap().chitchat();
         let mut chitchat_guard = chitchat.lock().await;
         for (key, value) in keys_values.into_iter() {
             chitchat_guard.self_node_state().set(key.clone(), value);
         }
     }
 
-    pub async fn mark_for_deletion(&mut self, node_id: NodeId, key: String) {
-        info!(node_id=%node_id.id, key=%key, "mark-for-deletion");
-        let chitchat = self.node_handles.get(&node_id).unwrap().chitchat();
+    pub async fn mark_for_deletion(&mut self, chitchat_id: ChitchatId, key: String) {
+        info!(node_id=%chitchat_id.node_id, key=%key, "mark-for-deletion");
+        let chitchat = self.node_handles.get(&chitchat_id).unwrap().chitchat();
         let mut chitchat_guard = chitchat.lock().await;
         chitchat_guard.self_node_state().mark_for_deletion(&key);
         let version = chitchat_guard
@@ -186,18 +196,27 @@ impl Simulator {
         info!(key=%key, version=version, "marked-for-deletion");
     }
 
-    pub async fn spawn_node(&mut self, node_id: NodeId, peer_seeds: Option<Vec<NodeId>>) {
-        info!(node_id=%node_id.id, "spawn");
+    pub async fn spawn_node(
+        &mut self,
+        chitchat_id: ChitchatId,
+        peer_seeds: Option<Vec<ChitchatId>>,
+    ) {
+        info!(node_id=%chitchat_id.node_id, "spawn");
         let seed_nodes: Vec<_> = peer_seeds
-            .unwrap_or_else(|| self.node_handles.keys().cloned().collect::<Vec<NodeId>>())
+            .unwrap_or_else(|| {
+                self.node_handles
+                    .keys()
+                    .cloned()
+                    .collect::<Vec<ChitchatId>>()
+            })
             .iter()
-            .map(|node_id| node_id.gossip_public_address.to_string())
+            .map(|chitchat_id| chitchat_id.gossip_advertise_address.to_string())
             .collect();
         let config = ChitchatConfig {
-            node_id: node_id.clone(),
+            chitchat_id: chitchat_id.clone(),
             cluster_id: "default-cluster".to_string(),
             gossip_interval: self.gossip_interval,
-            listen_addr: node_id.gossip_public_address,
+            listen_addr: chitchat_id.gossip_advertise_address,
             seed_nodes,
             failure_detector_config: FailureDetectorConfig {
                 initial_interval: self.gossip_interval * 10,
@@ -209,15 +228,16 @@ impl Simulator {
         let handle = spawn_chitchat(config, Vec::new(), &self.transport)
             .await
             .unwrap();
-        self.node_handles.insert(node_id, handle);
+        self.node_handles.insert(chitchat_id, handle);
     }
 }
 
-pub fn create_node_id(id: &str) -> NodeId {
+pub fn create_chitchat_id(id: &str) -> ChitchatId {
     let port = find_available_tcp_port().unwrap();
-    NodeId {
-        id: id.to_string(),
-        gossip_public_address: ([127, 0, 0, 1], port).into(),
+    ChitchatId {
+        node_id: id.to_string(),
+        generation_id: 0,
+        gossip_advertise_address: ([127, 0, 0, 1], port).into(),
     }
 }
 
@@ -236,34 +256,34 @@ pub fn find_available_tcp_port() -> anyhow::Result<u16> {
 async fn test_simple_simulation_insert() {
     let _ = tracing_subscriber::fmt::try_init();
     let mut simulator = Simulator::new(Duration::from_millis(50));
-    let node_id_1 = create_node_id("node-1");
-    let node_id_2 = create_node_id("node-2");
+    let chitchat_id_1 = create_chitchat_id("node-1");
+    let chitchat_id_2 = create_chitchat_id("node-2");
     let operations = vec![
         Operation::AddNode {
-            node_id: node_id_1.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             peer_seeds: None,
         },
         Operation::AddNode {
-            node_id: node_id_2.clone(),
+            chitchat_id: chitchat_id_2.clone(),
             peer_seeds: None,
         },
         Operation::InsertKeysValues {
-            node_id: node_id_1.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             keys_values: vec![("key_a".to_string(), "0".to_string())],
         },
         Operation::InsertKeysValues {
-            node_id: node_id_2.clone(),
+            chitchat_id: chitchat_id_2.clone(),
             keys_values: vec![("key_b".to_string(), "1".to_string())],
         },
         Operation::NodeStateAssert {
-            server_node_id: node_id_2.clone(),
-            node_id: node_id_1.clone(),
+            server_chitchat_id: chitchat_id_2.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::EqualKeyValue("key_a".to_string(), "0".to_string()),
             timeout_opt: Some(Duration::from_millis(200)),
         },
         Operation::NodeStateAssert {
-            server_node_id: node_id_1.clone(),
-            node_id: node_id_2.clone(),
+            server_chitchat_id: chitchat_id_1.clone(),
+            chitchat_id: chitchat_id_2.clone(),
             predicate: NodeStatePredicate::EqualKeyValue("key_b".to_string(), "1".to_string()),
             timeout_opt: None,
         },
@@ -275,37 +295,37 @@ async fn test_simple_simulation_insert() {
 async fn test_simple_simulation_with_network_partition() {
     let _ = tracing_subscriber::fmt::try_init();
     let mut simulator = Simulator::new(Duration::from_millis(50));
-    let node_id_1 = create_node_id("node-1");
-    let node_id_2 = create_node_id("node-2");
+    let chitchat_id_1 = create_chitchat_id("node-1");
+    let chitchat_id_2 = create_chitchat_id("node-2");
     let operations = vec![
         Operation::AddNode {
-            node_id: node_id_1.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             peer_seeds: None,
         },
         Operation::AddNode {
-            node_id: node_id_2.clone(),
+            chitchat_id: chitchat_id_2.clone(),
             peer_seeds: None,
         },
         Operation::InsertKeysValues {
-            node_id: node_id_1.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             keys_values: vec![("key_a".to_string(), "0".to_string())],
         },
         // Wait propagation of states.
         Operation::NodeStateAssert {
-            server_node_id: node_id_2.clone(),
-            node_id: node_id_1.clone(),
+            server_chitchat_id: chitchat_id_2.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::EqualKeyValue("key_a".to_string(), "0".to_string()),
             timeout_opt: Some(Duration::from_millis(500)),
         },
-        Operation::RemoveNetworkLink(node_id_1.clone(), node_id_2.clone()),
+        Operation::RemoveNetworkLink(chitchat_id_1.clone(), chitchat_id_2.clone()),
         Operation::InsertKeysValues {
-            node_id: node_id_2.clone(),
+            chitchat_id: chitchat_id_2.clone(),
             keys_values: vec![("key_b".to_string(), "1".to_string())],
         },
         // Wait propagation of states.
         Operation::NodeStateAssert {
-            server_node_id: node_id_1.clone(),
-            node_id: node_id_2.clone(),
+            server_chitchat_id: chitchat_id_1.clone(),
+            chitchat_id: chitchat_id_2.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_b".to_string(), false),
             timeout_opt: Some(Duration::from_millis(500)),
         },
@@ -317,103 +337,107 @@ async fn test_simple_simulation_with_network_partition() {
 async fn test_marked_for_deletion_gc_with_network_partition() {
     let _ = tracing_subscriber::fmt::try_init();
     let mut simulator = Simulator::new(Duration::from_millis(50));
-    let node_id_1 = create_node_id("node-1");
-    let node_id_2 = create_node_id("node-2");
-    let node_id_3 = create_node_id("node-3");
-    let node_id_4 = create_node_id("node-4");
-    let peer_seeds = vec![node_id_1.clone(), node_id_2.clone(), node_id_3.clone()];
+    let chitchat_id_1 = create_chitchat_id("node-1");
+    let chitchat_id_2 = create_chitchat_id("node-2");
+    let chitchat_id_3 = create_chitchat_id("node-3");
+    let chitchat_id_4 = create_chitchat_id("node-4");
+    let peer_seeds = vec![
+        chitchat_id_1.clone(),
+        chitchat_id_2.clone(),
+        chitchat_id_3.clone(),
+    ];
     let operations = vec![
         Operation::AddNode {
-            node_id: node_id_1.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             peer_seeds: Some(peer_seeds.clone()),
         },
         Operation::AddNode {
-            node_id: node_id_2.clone(),
+            chitchat_id: chitchat_id_2.clone(),
             peer_seeds: Some(peer_seeds.clone()),
         },
         Operation::AddNode {
-            node_id: node_id_3.clone(),
+            chitchat_id: chitchat_id_3.clone(),
             peer_seeds: Some(peer_seeds.clone()),
         },
         Operation::InsertKeysValues {
-            node_id: node_id_1.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             keys_values: vec![("key_a".to_string(), "0".to_string())],
         },
         Operation::NodeStateAssert {
-            server_node_id: node_id_2.clone(),
-            node_id: node_id_1.clone(),
+            server_chitchat_id: chitchat_id_2.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), true),
             timeout_opt: Some(Duration::from_millis(300)),
         },
         // Isolate node 3.
-        Operation::RemoveNetworkLink(node_id_1.clone(), node_id_3.clone()),
-        Operation::RemoveNetworkLink(node_id_2.clone(), node_id_3.clone()),
+        Operation::RemoveNetworkLink(chitchat_id_1.clone(), chitchat_id_3.clone()),
+        Operation::RemoveNetworkLink(chitchat_id_2.clone(), chitchat_id_3.clone()),
         // Mark for deletion key.
         Operation::MarkKeyForDeletion {
-            node_id: node_id_1.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             key: "key_a".to_string(),
         },
         // Check marked for deletion is propagated to node 2.
         Operation::NodeStateAssert {
-            server_node_id: node_id_2.clone(),
-            node_id: node_id_1.clone(),
+            server_chitchat_id: chitchat_id_2.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::MarkedForDeletion("key_a".to_string(), true),
             timeout_opt: Some(Duration::from_millis(300)),
         },
         // Wait for garbage collection
         Operation::Wait(Duration::from_millis(500)),
         Operation::NodeStateAssert {
-            server_node_id: node_id_2.clone(),
-            node_id: node_id_1.clone(),
+            server_chitchat_id: chitchat_id_2.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), false),
             timeout_opt: Some(Duration::from_millis(300)),
         },
         Operation::NodeStateAssert {
-            server_node_id: node_id_1.clone(),
-            node_id: node_id_1.clone(),
+            server_chitchat_id: chitchat_id_1.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), false),
             timeout_opt: None,
         },
         Operation::NodeStateAssert {
-            server_node_id: node_id_3.clone(),
-            node_id: node_id_1.clone(),
+            server_chitchat_id: chitchat_id_3.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::MarkedForDeletion("key_a".to_string(), false),
             timeout_opt: None,
         },
         // Add node 4 which communicates only with node 3.
-        Operation::RemoveNetworkLink(node_id_1.clone(), node_id_4.clone()),
-        Operation::RemoveNetworkLink(node_id_2.clone(), node_id_4.clone()),
+        Operation::RemoveNetworkLink(chitchat_id_1.clone(), chitchat_id_4.clone()),
+        Operation::RemoveNetworkLink(chitchat_id_2.clone(), chitchat_id_4.clone()),
         Operation::AddNode {
-            node_id: node_id_4.clone(),
-            peer_seeds: Some(vec![node_id_3.clone()]),
+            chitchat_id: chitchat_id_4.clone(),
+            peer_seeds: Some(vec![chitchat_id_3.clone()]),
         },
         // Wait for propagation
         // We need to wait longer... because node 4 is just starting?
         Operation::Wait(Duration::from_millis(1000)),
         Operation::NodeStateAssert {
-            server_node_id: node_id_3.clone(),
-            node_id: node_id_1.clone(),
+            server_chitchat_id: chitchat_id_3.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), true),
             timeout_opt: Some(Duration::from_millis(500)),
         },
         Operation::NodeStateAssert {
-            server_node_id: node_id_4.clone(),
-            node_id: node_id_1.clone(),
+            server_chitchat_id: chitchat_id_4.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), true),
             timeout_opt: Some(Duration::from_millis(500)),
         },
         // Relink node 3
-        Operation::AddNetworkLink(node_id_1.clone(), node_id_3.clone()),
-        Operation::AddNetworkLink(node_id_1.clone(), node_id_2.clone()),
+        Operation::AddNetworkLink(chitchat_id_1.clone(), chitchat_id_3.clone()),
+        Operation::AddNetworkLink(chitchat_id_1.clone(), chitchat_id_2.clone()),
         Operation::NodeStateAssert {
-            server_node_id: node_id_3.clone(),
-            node_id: node_id_1.clone(),
+            server_chitchat_id: chitchat_id_3.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), false),
             timeout_opt: Some(Duration::from_millis(500)),
         },
         Operation::NodeStateAssert {
-            server_node_id: node_id_4.clone(),
-            node_id: node_id_1.clone(),
+            server_chitchat_id: chitchat_id_4.clone(),
+            chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), false),
             timeout_opt: Some(Duration::from_millis(500)),
         },
@@ -427,53 +451,54 @@ async fn test_simple_simulation_heavy_insert_delete() {
     let _ = tracing_subscriber::fmt::try_init();
     let mut rng = thread_rng();
     let mut simulator = Simulator::new(Duration::from_millis(1000));
-    let mut node_ids = Vec::new();
+    let mut chitchat_ids = Vec::new();
     for i in 0..50 {
-        node_ids.push(create_node_id(&format!("node-{}", i)));
+        chitchat_ids.push(create_chitchat_id(&format!("node-{}", i)));
     }
     let seeds = vec![
-        node_ids[0].clone(),
-        node_ids[1].clone(),
-        node_ids[2].clone(),
+        chitchat_ids[0].clone(),
+        chitchat_ids[1].clone(),
+        chitchat_ids[2].clone(),
     ];
 
-    let add_node_operations: Vec<_> = node_ids
+    let add_node_operations: Vec<_> = chitchat_ids
         .iter()
-        .map(|node_id| Operation::AddNode {
-            node_id: node_id.clone(),
+        .map(|chitchat_id| Operation::AddNode {
+            chitchat_id: chitchat_id.clone(),
             peer_seeds: Some(seeds.clone()),
         })
         .collect();
     simulator.execute(add_node_operations).await;
 
     let key_names: Vec<_> = (0..50).map(|idx| format!("key_{}", idx)).collect();
-    let mut keys_values_inserted_per_node_id: HashMap<NodeId, HashSet<String>> = HashMap::new();
-    for node_id in node_ids.iter() {
+    let mut keys_values_inserted_per_chitchat_id: HashMap<ChitchatId, HashSet<String>> =
+        HashMap::new();
+    for chitchat_id in chitchat_ids.iter() {
         let mut keys_values = Vec::new();
         for key in key_names.iter() {
             let value: u64 = rng.gen();
             keys_values.push((key.to_string(), value.to_string()));
-            let keys_entry = keys_values_inserted_per_node_id
-                .entry(node_id.clone())
+            let keys_entry = keys_values_inserted_per_chitchat_id
+                .entry(chitchat_id.clone())
                 .or_insert_with(HashSet::new);
             keys_entry.insert(key.to_string());
         }
         simulator
             .execute(vec![Operation::InsertKeysValues {
-                node_id: node_id.clone(),
+                chitchat_id: chitchat_id.clone(),
                 keys_values,
             }])
             .await;
     }
 
     tokio::time::sleep(Duration::from_millis(5000)).await;
-    for (node_id, keys) in keys_values_inserted_per_node_id.clone().into_iter() {
-        info!(node_id=?node_id.id, keys=?keys, "check");
+    for (chitchat_id, keys) in keys_values_inserted_per_chitchat_id.clone().into_iter() {
+        info!(node_id=%chitchat_id.node_id, keys=?keys, "check");
         for key in keys {
-            let server_node_id = node_ids.choose(&mut rng).unwrap().clone();
+            let server_chitchat_id = chitchat_ids.choose(&mut rng).unwrap().clone();
             let check_operation = Operation::NodeStateAssert {
-                server_node_id,
-                node_id: node_id.clone(),
+                server_chitchat_id,
+                chitchat_id: chitchat_id.clone(),
                 predicate: NodeStatePredicate::KeyPresent(key.to_string(), true),
                 timeout_opt: None,
             };
@@ -482,10 +507,10 @@ async fn test_simple_simulation_heavy_insert_delete() {
     }
 
     // Marked all keys for deletion.
-    for (node_id, keys) in keys_values_inserted_per_node_id.clone().into_iter() {
+    for (chitchat_id, keys) in keys_values_inserted_per_chitchat_id.clone().into_iter() {
         for key in keys {
             let check_operation = Operation::MarkKeyForDeletion {
-                node_id: node_id.clone(),
+                chitchat_id: chitchat_id.clone(),
                 key,
             };
             simulator.execute(vec![check_operation]).await;
@@ -494,12 +519,12 @@ async fn test_simple_simulation_heavy_insert_delete() {
 
     // Wait for garbage collection to kick in.
     tokio::time::sleep(Duration::from_millis(10000)).await;
-    for (node_id, keys) in keys_values_inserted_per_node_id.clone().into_iter() {
+    for (chitchat_id, keys) in keys_values_inserted_per_chitchat_id.clone().into_iter() {
         for key in keys {
-            let server_node_id = node_ids.choose(&mut rng).unwrap().clone();
+            let server_chitchat_id = chitchat_ids.choose(&mut rng).unwrap().clone();
             let check_operation = Operation::NodeStateAssert {
-                server_node_id,
-                node_id: node_id.clone(),
+                server_chitchat_id,
+                chitchat_id: chitchat_id.clone(),
                 predicate: NodeStatePredicate::KeyPresent(key.to_string(), false),
                 timeout_opt: None,
             };


### PR DESCRIPTION
Chitchat and Quickwit use `NodeId` for different things, which makes the code in Quickwit very confusing.  So, I choose to rename `NodeId` to `ChitchatId`.

In addition, the Chitchat doc explains why you probably want to use a secondary id to detect node restarts, but then forces you into dealing with it yourself by appending some numeric ID to the node ID, which is cumbersome. In addition, encoding this ID as an integer actually consumes less bytes (8) than the string suffix alternative (13 bytes for a timestamp in millis + 1 for the separator char).