### PR TITLE
API change.

### DIFF
--- a/chitchat-test/Cargo.toml
+++ b/chitchat-test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chitchat = { version = "0.5.0", path = "../chitchat" }
+chitchat = { version = "0.6.0", path = "../chitchat" }
 poem = "1"
 poem-openapi = {version="1.3", features = ["swagger-ui"] }
 structopt = "0.3"

--- a/chitchat/Cargo.toml
+++ b/chitchat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chitchat"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]

--- a/chitchat/src/failure_detector.rs
+++ b/chitchat/src/failure_detector.rs
@@ -264,7 +264,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         let mut failure_detector = FailureDetector::new(FailureDetectorConfig::default());
 
-        let intervals_choices = vec![1u64, 2];
+        let intervals_choices = [1u64, 2];
         let chitchat_ids_choices = vec![
             ChitchatId::for_local_test(10_001),
             ChitchatId::for_local_test(10_002),
@@ -334,7 +334,7 @@ mod tests {
     fn test_failure_detector_node_state_from_live_to_down_to_live() {
         let mut rng = rand::thread_rng();
         let mut failure_detector = FailureDetector::new(FailureDetectorConfig::default());
-        let intervals_choices = vec![1u64, 2];
+        let intervals_choices = [1u64, 2];
         let node_1 = ChitchatId::for_local_test(10_001);
 
         for _ in 0..=2000 {


### PR DESCRIPTION
The key_value taking a predicate is useless, as it simply relies on Iterator::filter anyway.

Added a `.iter_prefix` method that relies on the BTreeMap ordering.