### PR TITLE
forget previous generations of a node when discovering a new one

### DIFF
--- a/chitchat-test/src/main.rs
+++ b/chitchat-test/src/main.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use chitchat::transport::UdpTransport;
 use chitchat::{spawn_chitchat, Chitchat, ChitchatConfig, ChitchatId, FailureDetectorConfig};
@@ -28,7 +28,11 @@ impl Api {
             cluster_id: chitchat_guard.cluster_id().to_string(),
             cluster_state: chitchat_guard.state_snapshot(),
             live_nodes: chitchat_guard.live_nodes().cloned().collect::<Vec<_>>(),
-            dead_nodes: chitchat_guard.dead_nodes().cloned().collect::<Vec<_>>(),
+            dead_nodes: chitchat_guard
+                .dead_nodes()
+                .cloned()
+                .map(|node| node.0)
+                .collect::<Vec<_>>(),
         };
         Json(serde_json::to_value(&response).unwrap())
     }
@@ -84,7 +88,11 @@ async fn main() -> anyhow::Result<()> {
     let node_id = opt
         .node_id
         .unwrap_or_else(|| generate_server_id(public_addr));
-    let chitchat_id = ChitchatId::new(node_id, 0, public_addr);
+    let generation = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let chitchat_id = ChitchatId::new(node_id, generation, public_addr);
     let config = ChitchatConfig {
         cluster_id: "testing".to_string(),
         chitchat_id,

--- a/chitchat/src/delta.rs
+++ b/chitchat/src/delta.rs
@@ -2,40 +2,40 @@ use std::collections::{BTreeMap, HashSet};
 use std::mem;
 
 use crate::serialize::*;
-use crate::{ChitchatId, Heartbeat, MaxVersion, VersionedValue};
+use crate::{ChitchatId, ChitchatIdGenerationEq, Heartbeat, MaxVersion, VersionedValue};
 
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct Delta {
-    pub(crate) node_deltas: BTreeMap<ChitchatId, NodeDelta>,
-    pub(crate) nodes_to_reset: HashSet<ChitchatId>,
+    pub(crate) node_deltas: BTreeMap<ChitchatIdGenerationEq, NodeDelta>,
+    pub(crate) nodes_to_reset: HashSet<ChitchatIdGenerationEq>,
 }
 
 impl Serializable for Delta {
     fn serialize(&self, buf: &mut Vec<u8>) {
         (self.node_deltas.len() as u16).serialize(buf);
         for (chitchat_id, node_delta) in &self.node_deltas {
-            chitchat_id.serialize(buf);
+            chitchat_id.0.serialize(buf);
             node_delta.serialize(buf);
         }
         (self.nodes_to_reset.len() as u16).serialize(buf);
         for chitchat_id in &self.nodes_to_reset {
-            chitchat_id.serialize(buf);
+            chitchat_id.0.serialize(buf);
         }
     }
 
     fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
-        let mut node_deltas: BTreeMap<ChitchatId, NodeDelta> = Default::default();
+        let mut node_deltas: BTreeMap<ChitchatIdGenerationEq, NodeDelta> = Default::default();
         let num_nodes = u16::deserialize(buf)?;
         for _ in 0..num_nodes {
             let chitchat_id = ChitchatId::deserialize(buf)?;
             let node_delta = NodeDelta::deserialize(buf)?;
-            node_deltas.insert(chitchat_id, node_delta);
+            node_deltas.insert(ChitchatIdGenerationEq(chitchat_id), node_delta);
         }
         let num_nodes_to_reset = u16::deserialize(buf)?;
         let mut nodes_to_reset = HashSet::with_capacity(num_nodes_to_reset as usize);
         for _ in 0..num_nodes_to_reset {
             let chitchat_id = ChitchatId::deserialize(buf)?;
-            nodes_to_reset.insert(chitchat_id);
+            nodes_to_reset.insert(ChitchatIdGenerationEq(chitchat_id));
         }
         Ok(Delta {
             node_deltas,
@@ -46,12 +46,12 @@ impl Serializable for Delta {
     fn serialized_len(&self) -> usize {
         let mut len = 2;
         for (chitchat_id, node_delta) in &self.node_deltas {
-            len += chitchat_id.serialized_len();
+            len += chitchat_id.0.serialized_len();
             len += node_delta.serialized_len();
         }
         len += 2;
         for chitchat_id in &self.nodes_to_reset {
-            len += chitchat_id.serialized_len();
+            len += chitchat_id.0.serialized_len();
         }
         len
     }
@@ -68,7 +68,7 @@ impl Delta {
 
     pub fn add_node(&mut self, chitchat_id: ChitchatId, heartbeat: Heartbeat) {
         self.node_deltas
-            .entry(chitchat_id)
+            .entry(ChitchatIdGenerationEq(chitchat_id))
             .or_insert_with(|| NodeDelta {
                 heartbeat,
                 ..Default::default()
@@ -83,7 +83,10 @@ impl Delta {
         version: crate::Version,
         tombstone: Option<u64>,
     ) {
-        let node_delta = self.node_deltas.get_mut(chitchat_id).unwrap();
+        let node_delta = self
+            .node_deltas
+            .get_mut(&ChitchatIdGenerationEq(chitchat_id.clone()))
+            .unwrap();
 
         node_delta.max_version = node_delta.max_version.max(version);
         node_delta.key_values.insert(
@@ -97,7 +100,8 @@ impl Delta {
     }
 
     pub fn add_node_to_reset(&mut self, chitchat_id: ChitchatId) {
-        self.nodes_to_reset.insert(chitchat_id);
+        self.nodes_to_reset
+            .insert(ChitchatIdGenerationEq(chitchat_id));
     }
 }
 
@@ -141,13 +145,16 @@ impl DeltaWriter {
         let chitchat_id_opt = mem::take(&mut self.current_chitchat_id);
         let node_delta = mem::take(&mut self.current_node_delta);
         if let Some(chitchat_id) = chitchat_id_opt {
-            self.delta.node_deltas.insert(chitchat_id, node_delta);
+            self.delta
+                .node_deltas
+                .insert(ChitchatIdGenerationEq(chitchat_id), node_delta);
         }
     }
 
     pub fn add_node_to_reset(&mut self, chitchat_id: ChitchatId) -> bool {
+        let chitchat_id = ChitchatIdGenerationEq(chitchat_id);
         assert!(!self.delta.nodes_to_reset.contains(&chitchat_id));
-        if !self.attempt_add_bytes(chitchat_id.serialized_len()) {
+        if !self.attempt_add_bytes(chitchat_id.0.serialized_len()) {
             return false;
         }
         self.delta.nodes_to_reset.insert(chitchat_id);
@@ -155,15 +162,21 @@ impl DeltaWriter {
     }
 
     pub fn add_node(&mut self, chitchat_id: ChitchatId, heartbeat: Heartbeat) -> bool {
-        assert!(self.current_chitchat_id.as_ref() != Some(&chitchat_id));
+        assert!(self
+            .current_chitchat_id
+            .as_ref()
+            .map(|current_node| !current_node.eq_generation(&chitchat_id))
+            .unwrap_or(true));
+        let chitchat_id = ChitchatIdGenerationEq(chitchat_id);
         assert!(!self.delta.node_deltas.contains_key(&chitchat_id));
         self.flush();
         // Reserve bytes for [`ChitchatId`], [`Hearbeat`], and for an empty [`NodeDelta`] which has
         // a size of 2 bytes.
-        if !self.attempt_add_bytes(chitchat_id.serialized_len() + heartbeat.serialized_len() + 2) {
+        if !self.attempt_add_bytes(chitchat_id.0.serialized_len() + heartbeat.serialized_len() + 2)
+        {
             return false;
         }
-        self.current_chitchat_id = Some(chitchat_id);
+        self.current_chitchat_id = Some(chitchat_id.0);
         self.current_node_delta.heartbeat = heartbeat;
         true
     }

--- a/chitchat/src/digest.rs
+++ b/chitchat/src/digest.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::serialize::*;
-use crate::{ChitchatId, Heartbeat, MaxVersion};
+use crate::{ChitchatId, ChitchatIdGenerationEq, Heartbeat, MaxVersion};
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 pub(crate) struct NodeDigest {
@@ -25,14 +25,15 @@ impl NodeDigest {
 /// peer -> (heartbeat, max version).
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct Digest {
-    pub(crate) node_digests: BTreeMap<ChitchatId, NodeDigest>,
+    pub(crate) node_digests: BTreeMap<ChitchatIdGenerationEq, NodeDigest>,
 }
 
 #[cfg(test)]
 impl Digest {
     pub fn add_node(&mut self, node: ChitchatId, heartbeat: Heartbeat, max_version: MaxVersion) {
         let node_digest = NodeDigest::new(heartbeat, max_version);
-        self.node_digests.insert(node, node_digest);
+        self.node_digests
+            .insert(ChitchatIdGenerationEq(node), node_digest);
     }
 }
 
@@ -40,7 +41,7 @@ impl Serializable for Digest {
     fn serialize(&self, buf: &mut Vec<u8>) {
         (self.node_digests.len() as u16).serialize(buf);
         for (chitchat_id, node_digest) in &self.node_digests {
-            chitchat_id.serialize(buf);
+            chitchat_id.0.serialize(buf);
             node_digest.heartbeat.serialize(buf);
             node_digest.max_version.serialize(buf);
         }
@@ -48,14 +49,14 @@ impl Serializable for Digest {
 
     fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
         let num_nodes = u16::deserialize(buf)?;
-        let mut node_digests: BTreeMap<ChitchatId, NodeDigest> = Default::default();
+        let mut node_digests: BTreeMap<ChitchatIdGenerationEq, NodeDigest> = Default::default();
 
         for _ in 0..num_nodes {
             let chitchat_id = ChitchatId::deserialize(buf)?;
             let heartbeat = Heartbeat::deserialize(buf)?;
             let max_version = u64::deserialize(buf)?;
             let node_digest = NodeDigest::new(heartbeat, max_version);
-            node_digests.insert(chitchat_id, node_digest);
+            node_digests.insert(ChitchatIdGenerationEq(chitchat_id), node_digest);
         }
         Ok(Digest { node_digests })
     }
@@ -63,7 +64,7 @@ impl Serializable for Digest {
     fn serialized_len(&self) -> usize {
         let mut len = (self.node_digests.len() as u16).serialized_len();
         for (chitchat_id, node_digest) in &self.node_digests {
-            len += chitchat_id.serialized_len();
+            len += chitchat_id.0.serialized_len();
             len += node_digest.heartbeat.serialized_len();
             len += node_digest.max_version.serialized_len();
         }

--- a/chitchat/src/lib.rs
+++ b/chitchat/src/lib.rs
@@ -32,7 +32,10 @@ use crate::message::syn_ack_serialized_len;
 pub use crate::message::ChitchatMessage;
 pub use crate::server::{spawn_chitchat, ChitchatHandle};
 use crate::state::ClusterState;
-pub use crate::types::{ChitchatId, Heartbeat, MaxVersion, Version, VersionedValue};
+pub use crate::types::{
+    ChitchatId, ChitchatIdGenerationEq, ChitchatIdNodeEq, Heartbeat, MaxVersion, Version,
+    VersionedValue,
+};
 
 /// Maximum UDP datagram payload size (in bytes).
 ///
@@ -50,9 +53,9 @@ pub struct Chitchat {
     cluster_state: ClusterState,
     failure_detector: FailureDetector,
     /// Notifies listeners when a change has occurred in the set of live nodes.
-    previous_live_nodes: HashMap<ChitchatId, MaxVersion>,
-    live_nodes_watcher_tx: watch::Sender<BTreeMap<ChitchatId, NodeState>>,
-    live_nodes_watcher_rx: watch::Receiver<BTreeMap<ChitchatId, NodeState>>,
+    previous_live_nodes: HashMap<ChitchatIdGenerationEq, MaxVersion>,
+    live_nodes_watcher_tx: watch::Sender<BTreeMap<ChitchatIdGenerationEq, NodeState>>,
+    live_nodes_watcher_rx: watch::Receiver<BTreeMap<ChitchatIdGenerationEq, NodeState>>,
 }
 
 impl Chitchat {
@@ -160,11 +163,16 @@ impl Chitchat {
     /// update.
     fn report_heartbeats(&mut self, delta: &Delta) {
         for (chitchat_id, node_delta) in &delta.node_deltas {
-            if let Some(node_state) = self.cluster_state.node_states.get(chitchat_id) {
+            if let Some((node_id, node_state)) = self
+                .cluster_state
+                .node_states
+                .get_key_value(&ChitchatIdNodeEq(chitchat_id.0.clone()))
+            {
                 if node_state.heartbeat() < node_delta.heartbeat
                     || node_state.max_version() < node_delta.max_version
+                    || node_id.0.generation_id < chitchat_id.0.generation_id
                 {
-                    self.failure_detector.report_heartbeat(chitchat_id);
+                    self.failure_detector.report_heartbeat(&chitchat_id.0);
                 }
             }
         }
@@ -175,7 +183,7 @@ impl Chitchat {
     pub(crate) fn update_nodes_liveness(&mut self) {
         self.cluster_state
             .nodes()
-            .filter(|&chitchat_id| *chitchat_id != self.config.chitchat_id)
+            .filter(|&chitchat_id| !chitchat_id.eq_node_id(&self.config.chitchat_id))
             .for_each(|chitchat_id| {
                 self.failure_detector.update_node_liveness(chitchat_id);
             });
@@ -186,7 +194,10 @@ impl Chitchat {
                 let node_state = self
                     .node_state(chitchat_id)
                     .expect("Node state should exist.");
-                (chitchat_id.clone(), node_state.max_version())
+                (
+                    ChitchatIdGenerationEq(chitchat_id.clone()),
+                    node_state.max_version(),
+                )
             })
             .collect::<HashMap<_, _>>();
 
@@ -196,7 +207,7 @@ impl Chitchat {
                 .cloned()
                 .map(|chitchat_id| {
                     let node_state = self
-                        .node_state(&chitchat_id)
+                        .node_state(&chitchat_id.0)
                         .expect("Node state should exist.")
                         .clone();
                     (chitchat_id, node_state)
@@ -215,7 +226,7 @@ impl Chitchat {
         }
     }
 
-    pub fn node_states(&self) -> &BTreeMap<ChitchatId, NodeState> {
+    pub fn node_states(&self) -> &BTreeMap<ChitchatIdNodeEq, NodeState> {
         &self.cluster_state.node_states
     }
 
@@ -230,7 +241,7 @@ impl Chitchat {
     /// Returns the set of nodes considered alive by the failure detector. It includes the
     /// current node (also called "self node"), which is always considered alive.
     pub fn live_nodes(&self) -> impl Iterator<Item = &ChitchatId> {
-        once(self.self_chitchat_id()).chain(self.failure_detector.live_nodes())
+        once(self.self_chitchat_id()).chain(self.failure_detector.live_nodes().map(|node| &node.0))
     }
 
     /// Returns a watch stream for monitoring changes in the cluster.
@@ -241,12 +252,12 @@ impl Chitchat {
     /// - updates its max version
     ///
     /// Heartbeats are not notified.
-    pub fn live_nodes_watcher(&self) -> WatchStream<BTreeMap<ChitchatId, NodeState>> {
+    pub fn live_nodes_watcher(&self) -> WatchStream<BTreeMap<ChitchatIdGenerationEq, NodeState>> {
         WatchStream::new(self.live_nodes_watcher_rx.clone())
     }
 
     /// Returns the set of nodes considered dead by the failure detector.
-    pub fn dead_nodes(&self) -> impl Iterator<Item = &ChitchatId> {
+    pub fn dead_nodes(&self) -> impl Iterator<Item = &ChitchatIdNodeEq> {
         self.failure_detector.dead_nodes()
     }
 
@@ -278,7 +289,7 @@ impl Chitchat {
     }
 
     /// Computes the node's digest.
-    fn compute_digest(&self, dead_nodes: &HashSet<&ChitchatId>) -> Digest {
+    fn compute_digest(&self, dead_nodes: &HashSet<&ChitchatIdNodeEq>) -> Digest {
         self.cluster_state.compute_digest(dead_nodes)
     }
 
@@ -308,7 +319,7 @@ impl Chitchat {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone)]
 pub struct KeyChangeEvent<'a> {
     /// The matching key without the prefix used to subscribe to the event.
     pub key: &'a str,
@@ -316,6 +327,13 @@ pub struct KeyChangeEvent<'a> {
     pub value: &'a str,
     /// The node for which the event was triggered.
     pub node: &'a ChitchatId,
+}
+
+impl<'a> Eq for KeyChangeEvent<'a> {}
+impl<'a> PartialEq for KeyChangeEvent<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key && self.value == other.value && self.node.eq_generation(&other.node)
+    }
 }
 
 impl<'a> KeyChangeEvent<'a> {
@@ -408,7 +426,7 @@ mod tests {
         for chitchat_id in &chitchat_ids[1..] {
             let seeds = chitchat_ids
                 .iter()
-                .filter(|&peer_id| peer_id != chitchat_id)
+                .filter(|&peer_id| !peer_id.eq_node_id(chitchat_id))
                 .map(|peer_id| peer_id.gossip_advertise_addr.to_string())
                 .collect::<Vec<_>>();
             chitchat_handlers.push(start_node(chitchat_id.clone(), &seeds, transport).await);
@@ -434,6 +452,10 @@ mod tests {
         chitchat: Arc<Mutex<Chitchat>>,
         expected_nodes: &[ChitchatId],
     ) {
+        let expected_nodes: Vec<_> = expected_nodes
+            .iter()
+            .map(|node| ChitchatIdGenerationEq(node.clone()))
+            .collect();
         let expected_nodes = expected_nodes.iter().collect::<HashSet<_>>();
         let mut live_nodes_watcher =
             chitchat

--- a/chitchat/src/serialize.rs
+++ b/chitchat/src/serialize.rs
@@ -269,9 +269,18 @@ mod tests {
 
     #[test]
     fn test_serialize_chitchat_id() {
-        test_serdeser_aux(
-            &ChitchatId::new("node-id".to_string(), 1, "127.0.0.1:7280".parse().unwrap()),
-            24,
+        // we cant use test_serdeser_aux because ChitchatId isn't Eq
+        let obj = ChitchatId::new("node-id".to_string(), 1, "127.0.0.1:7280".parse().unwrap());
+        let num_bytes = 24;
+
+        let mut buf = Vec::new();
+        obj.serialize(&mut buf);
+        assert_eq!(buf.len(), obj.serialized_len());
+        assert_eq!(buf.len(), num_bytes);
+        let obj_serdeser = ChitchatId::deserialize(&mut &buf[..]).unwrap();
+        assert!(
+            obj.eq_generation(&obj_serdeser)
+                && obj.gossip_advertise_addr == obj_serdeser.gossip_advertise_addr
         );
     }
 

--- a/chitchat/src/state.rs
+++ b/chitchat/src/state.rs
@@ -15,7 +15,10 @@ use tracing::warn;
 use crate::delta::{Delta, DeltaWriter};
 use crate::digest::{Digest, NodeDigest};
 use crate::listener::Listeners;
-use crate::{ChitchatId, Heartbeat, KeyChangeEvent, MaxVersion, Version, VersionedValue};
+use crate::{
+    ChitchatId, ChitchatIdGenerationEq, ChitchatIdNodeEq, Heartbeat, KeyChangeEvent, MaxVersion,
+    Version, VersionedValue,
+};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct NodeState {
@@ -230,7 +233,9 @@ impl NodeState {
 }
 
 pub(crate) struct ClusterState {
-    pub(crate) node_states: BTreeMap<ChitchatId, NodeState>,
+    // when inserting in this map, it's up to you to make sure you store the newest generation,
+    // which possibly means removing and reinserting a key.
+    pub(crate) node_states: BTreeMap<ChitchatIdNodeEq, NodeState>,
     seed_addrs: watch::Receiver<HashSet<SocketAddr>>,
     pub(crate) listeners: Listeners,
 }
@@ -268,16 +273,16 @@ impl ClusterState {
     pub(crate) fn node_state_mut(&mut self, chitchat_id: &ChitchatId) -> &mut NodeState {
         // TODO use the `hash_raw_entry` feature once it gets stabilized.
         self.node_states
-            .entry(chitchat_id.clone())
+            .entry(ChitchatIdNodeEq(chitchat_id.clone()))
             .or_insert_with(|| NodeState::new(chitchat_id.clone(), self.listeners.clone()))
     }
 
     pub fn node_state(&self, chitchat_id: &ChitchatId) -> Option<&NodeState> {
-        self.node_states.get(chitchat_id)
+        self.node_states.get(&ChitchatIdNodeEq(chitchat_id.clone()))
     }
 
     pub fn nodes(&self) -> impl Iterator<Item = &ChitchatId> {
-        self.node_states.keys()
+        self.node_states.keys().map(|node| &node.0)
     }
 
     pub fn seed_addrs(&self) -> HashSet<SocketAddr> {
@@ -285,20 +290,38 @@ impl ClusterState {
     }
 
     pub(crate) fn remove_node(&mut self, chitchat_id: &ChitchatId) {
-        self.node_states.remove(chitchat_id);
+        self.node_states
+            .remove(&ChitchatIdNodeEq(chitchat_id.clone()));
     }
 
+    /// Apply a delta, ignoring any entry from a previous relay of `me`.
     pub(crate) fn apply_delta(&mut self, delta: Delta) {
         // Remove nodes to reset.
-        self.node_states
-            .retain(|chitchat_id, _| !delta.nodes_to_reset.contains(chitchat_id));
+        self.node_states.retain(|chitchat_id, _| {
+            !delta
+                .nodes_to_reset
+                .iter()
+                .any(|to_reset| to_reset.0.eq_generation(&chitchat_id.0))
+        });
 
         // Apply delta.
         for (chitchat_id, node_delta) in delta.node_deltas {
-            let node_state = self
+            // we remove and re-insert to update the key in case generation changed.
+            let mut node_state = if let Some((old_chitchat_id, old_state)) = self
                 .node_states
-                .entry(chitchat_id.clone())
-                .or_insert_with(|| NodeState::new(chitchat_id, self.listeners.clone()));
+                .remove_entry(&ChitchatIdNodeEq(chitchat_id.0.clone()))
+            {
+                let old_chichat_id = ChitchatIdGenerationEq(old_chitchat_id.0);
+                if old_chichat_id > chitchat_id {
+                    // we know a newer generation, restore the write and ignore that bit of delta.
+                    self.node_states
+                        .insert(ChitchatIdNodeEq(old_chichat_id.0), old_state);
+                    continue;
+                }
+                old_state
+            } else {
+                NodeState::new(chitchat_id.0.clone(), self.listeners.clone())
+            };
             if node_state.heartbeat < node_delta.heartbeat {
                 node_state.heartbeat = node_delta.heartbeat;
                 node_state.last_heartbeat = Instant::now();
@@ -308,16 +331,23 @@ impl ClusterState {
                 node_state.max_version = node_state.max_version.max(versioned_value.version);
                 node_state.set_versioned_value(key, versioned_value);
             }
+            self.node_states
+                .insert(ChitchatIdNodeEq(chitchat_id.0), node_state);
         }
     }
 
-    pub fn compute_digest(&self, dead_nodes: &HashSet<&ChitchatId>) -> Digest {
+    pub fn compute_digest(&self, dead_nodes: &HashSet<&ChitchatIdNodeEq>) -> Digest {
         Digest {
             node_digests: self
                 .node_states
                 .iter()
                 .filter(|(chitchat_id, _)| !dead_nodes.contains(chitchat_id))
-                .map(|(chitchat_id, node_state)| (chitchat_id.clone(), node_state.digest()))
+                .map(|(chitchat_id, node_state)| {
+                    (
+                        ChitchatIdGenerationEq(chitchat_id.0.clone()),
+                        node_state.digest(),
+                    )
+                })
                 .collect(),
         }
     }
@@ -325,7 +355,7 @@ impl ClusterState {
     pub fn gc_keys_marked_for_deletion(
         &mut self,
         marked_for_deletion_grace_period: u64,
-        dead_nodes: &HashSet<ChitchatId>,
+        dead_nodes: &HashSet<ChitchatIdNodeEq>,
     ) {
         for (chitchat_id, node_state) in &mut self.node_states {
             if dead_nodes.contains(chitchat_id) {
@@ -340,7 +370,7 @@ impl ClusterState {
         &self,
         digest: &Digest,
         mtu: usize,
-        dead_nodes: &HashSet<&ChitchatId>,
+        dead_nodes: &HashSet<&ChitchatIdNodeEq>,
         marked_for_deletion_grace_period: u64,
     ) -> Delta {
         let mut stale_nodes = SortedStaleNodes::default();
@@ -350,17 +380,20 @@ impl ClusterState {
             if dead_nodes.contains(chitchat_id) {
                 continue;
             }
-            let Some(node_digest) = digest.node_digests.get(chitchat_id) else {
-                stale_nodes.insert(chitchat_id, node_state);
+            let Some(node_digest) = digest
+                .node_digests
+                .get(&ChitchatIdGenerationEq(chitchat_id.0.clone()))
+            else {
+                stale_nodes.insert(&chitchat_id.0, node_state);
                 continue;
             };
             if node_digest.heartbeat.0 + marked_for_deletion_grace_period < node_state.heartbeat.0 {
                 warn!("Node to reset {chitchat_id:?}");
-                nodes_to_reset.push(chitchat_id);
-                stale_nodes.insert(chitchat_id, node_state);
+                nodes_to_reset.push(&chitchat_id.0);
+                stale_nodes.insert(&chitchat_id.0, node_state);
                 continue;
             }
-            stale_nodes.offer(chitchat_id, node_state, node_digest);
+            stale_nodes.offer(&chitchat_id.0, node_state, node_digest);
         }
         let mut delta_writer = DeltaWriter::with_mtu(mtu);
 
@@ -491,7 +524,7 @@ impl From<&ClusterState> for ClusterStateSnapshot {
             .node_states
             .iter()
             .map(|(chitchat_id, node_state)| NodeStateSnapshot {
-                chitchat_id: chitchat_id.clone(),
+                chitchat_id: chitchat_id.0.clone(),
                 node_state: node_state.clone(),
             })
             .collect();
@@ -825,7 +858,8 @@ mod tests {
         assert_eq!(&digest, &expected_node_digests);
 
         // Consider node 1 dead:
-        let dead_nodes = HashSet::from_iter([&node1]);
+        let dead_node = ChitchatIdNodeEq(node1);
+        let dead_nodes = HashSet::from_iter([&dead_node]);
         let digest = cluster_state.compute_digest(&dead_nodes);
 
         let mut expected_node_digests = Digest::default();
@@ -934,7 +968,7 @@ mod tests {
     fn test_with_varying_max_transmitted_kv_helper(
         cluster_state: &ClusterState,
         digest: &Digest,
-        dead_nodes: &HashSet<&ChitchatId>,
+        dead_nodes: &HashSet<&ChitchatIdNodeEq>,
         expected_delta_atoms: &[(&ChitchatId, &str, &str, Version, Option<u64>)],
     ) {
         let max_delta = cluster_state.compute_delta(digest, usize::MAX, dead_nodes, 10_000);
@@ -1060,7 +1094,8 @@ mod tests {
         let node1 = ChitchatId::for_local_test(10_001);
         let node2 = ChitchatId::for_local_test(10_002);
 
-        let dead_nodes = HashSet::from_iter([&node2]);
+        let dead_node = ChitchatIdNodeEq(node2);
+        let dead_nodes = HashSet::from_iter([&dead_node]);
 
         test_with_varying_max_transmitted_kv_helper(
             &cluster_state,

--- a/chitchat/src/types.rs
+++ b/chitchat/src/types.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 
 use serde::{Deserialize, Serialize};
@@ -13,7 +15,13 @@ use serde::{Deserialize, Serialize};
 /// leaves and rejoins the cluster. Backends such as Cassandra or Quickwit typically use the node's
 /// startup time as the `generation_id`. Applications with stable state across restarts can use a
 /// constant `generation_id`, for instance, `0`.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+// This type doesn't implement Eq & co because there are multiple notions of equality depending
+// on what you want to do with it. Nodes with the same node_id are the same by definition, so
+// sometime checking node_id is enough, but sometime we want to compare ChitchatId for generations,
+// in which case node_id+generation_id needs to be compared. Mixing both is easy and can lead to
+// bugs. Instead you have to use dedicated methods and/or wrappers depending on what equality means
+// for you in this context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChitchatId {
     /// An identifier unique across the cluster.
     pub node_id: String,
@@ -31,6 +39,14 @@ impl ChitchatId {
             gossip_advertise_addr,
         }
     }
+
+    pub fn eq_node_id(&self, other: &ChitchatId) -> bool {
+        self.node_id == other.node_id
+    }
+
+    pub fn eq_generation(&self, other: &ChitchatId) -> bool {
+        self.eq_node_id(other) && self.generation_id == other.generation_id
+    }
 }
 
 #[cfg(any(test, feature = "testsuite"))]
@@ -43,6 +59,60 @@ impl ChitchatId {
     /// Creates a new [`ChitchatId`] for local testing.
     pub fn for_local_test(port: u16) -> Self {
         Self::new(format!("node-{port}"), 0, ([127, 0, 0, 1], port).into())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ChitchatIdNodeEq(pub ChitchatId);
+
+impl Eq for ChitchatIdNodeEq {}
+impl PartialEq for ChitchatIdNodeEq {
+    fn eq(&self, other: &ChitchatIdNodeEq) -> bool {
+        self.0.eq_node_id(&other.0)
+    }
+}
+impl Hash for ChitchatIdNodeEq {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.node_id.hash(state);
+    }
+}
+impl Ord for ChitchatIdNodeEq {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.node_id.cmp(&other.0.node_id)
+    }
+}
+impl PartialOrd for ChitchatIdNodeEq {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ChitchatIdGenerationEq(pub ChitchatId);
+
+impl Eq for ChitchatIdGenerationEq {}
+impl PartialEq for ChitchatIdGenerationEq {
+    fn eq(&self, other: &ChitchatIdGenerationEq) -> bool {
+        self.0.eq_generation(&other.0)
+    }
+}
+impl Hash for ChitchatIdGenerationEq {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.node_id.hash(state);
+        self.0.generation_id.hash(state);
+    }
+}
+impl Ord for ChitchatIdGenerationEq {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0
+            .node_id
+            .cmp(&other.0.node_id)
+            .then(self.0.generation_id.cmp(&other.0.generation_id))
+    }
+}
+impl PartialOrd for ChitchatIdGenerationEq {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/chitchat/tests/perf_test.rs
+++ b/chitchat/tests/perf_test.rs
@@ -4,7 +4,8 @@ use std::time::Duration;
 
 use chitchat::transport::{ChannelTransport, Transport, TransportExt};
 use chitchat::{
-    spawn_chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig, NodeState,
+    spawn_chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, ChitchatIdGenerationEq,
+    FailureDetectorConfig, NodeState,
 };
 use tokio::time::Instant;
 use tokio_stream::StreamExt;
@@ -42,7 +43,7 @@ async fn spawn_nodes(num_nodes: u16, transport: &dyn Transport) -> Vec<ChitchatH
     handles
 }
 
-async fn wait_until<P: Fn(&BTreeMap<ChitchatId, NodeState>) -> bool>(
+async fn wait_until<P: Fn(&BTreeMap<ChitchatIdGenerationEq, NodeState>) -> bool>(
     handle: &ChitchatHandle,
     predicate: P,
 ) -> Duration {


### PR DESCRIPTION
fix #94 

remove impl of PartialEq & co from ChitchatId as it is very error prone due to multiple notion of equality on that struct.