### PR TITLE
Make serialize module public to align with transport module

### DIFF
--- a/chitchat/src/lib.rs
+++ b/chitchat/src/lib.rs
@@ -7,7 +7,7 @@ mod digest;
 mod failure_detector;
 mod listener;
 mod message;
-pub(crate) mod serialize;
+pub mod serialize;
 mod server;
 mod state;
 pub mod transport;


### PR DESCRIPTION
Addresses https://github.com/quickwit-oss/chitchat/issues/78