### PR TITLE
forget previous generation

### DIFF
--- a/chitchat-test/src/main.rs
+++ b/chitchat-test/src/main.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use chitchat::transport::UdpTransport;
 use chitchat::{spawn_chitchat, Chitchat, ChitchatConfig, ChitchatId, FailureDetectorConfig};
@@ -28,11 +28,7 @@ impl Api {
             cluster_id: chitchat_guard.cluster_id().to_string(),
             cluster_state: chitchat_guard.state_snapshot(),
             live_nodes: chitchat_guard.live_nodes().cloned().collect::<Vec<_>>(),
-            dead_nodes: chitchat_guard
-                .dead_nodes()
-                .cloned()
-                .map(|node| node.0)
-                .collect::<Vec<_>>(),
+            dead_nodes: chitchat_guard.dead_nodes().cloned().collect::<Vec<_>>(),
         };
         Json(serde_json::to_value(&response).unwrap())
     }
@@ -88,11 +84,7 @@ async fn main() -> anyhow::Result<()> {
     let node_id = opt
         .node_id
         .unwrap_or_else(|| generate_server_id(public_addr));
-    let generation = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    let chitchat_id = ChitchatId::new(node_id, generation, public_addr);
+    let chitchat_id = ChitchatId::new(node_id, 0, public_addr);
     let config = ChitchatConfig {
         cluster_id: "testing".to_string(),
         chitchat_id,

--- a/chitchat/src/digest.rs
+++ b/chitchat/src/digest.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::serialize::*;
-use crate::{ChitchatId, ChitchatIdGenerationEq, Heartbeat, MaxVersion};
+use crate::{ChitchatId, Heartbeat, MaxVersion};
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 pub(crate) struct NodeDigest {
@@ -25,15 +25,14 @@ impl NodeDigest {
 /// peer -> (heartbeat, max version).
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct Digest {
-    pub(crate) node_digests: BTreeMap<ChitchatIdGenerationEq, NodeDigest>,
+    pub(crate) node_digests: BTreeMap<ChitchatId, NodeDigest>,
 }
 
 #[cfg(test)]
 impl Digest {
     pub fn add_node(&mut self, node: ChitchatId, heartbeat: Heartbeat, max_version: MaxVersion) {
         let node_digest = NodeDigest::new(heartbeat, max_version);
-        self.node_digests
-            .insert(ChitchatIdGenerationEq(node), node_digest);
+        self.node_digests.insert(node, node_digest);
     }
 }
 
@@ -41,7 +40,7 @@ impl Serializable for Digest {
     fn serialize(&self, buf: &mut Vec<u8>) {
         (self.node_digests.len() as u16).serialize(buf);
         for (chitchat_id, node_digest) in &self.node_digests {
-            chitchat_id.0.serialize(buf);
+            chitchat_id.serialize(buf);
             node_digest.heartbeat.serialize(buf);
             node_digest.max_version.serialize(buf);
         }
@@ -49,14 +48,14 @@ impl Serializable for Digest {
 
     fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
         let num_nodes = u16::deserialize(buf)?;
-        let mut node_digests: BTreeMap<ChitchatIdGenerationEq, NodeDigest> = Default::default();
+        let mut node_digests: BTreeMap<ChitchatId, NodeDigest> = Default::default();
 
         for _ in 0..num_nodes {
             let chitchat_id = ChitchatId::deserialize(buf)?;
             let heartbeat = Heartbeat::deserialize(buf)?;
             let max_version = u64::deserialize(buf)?;
             let node_digest = NodeDigest::new(heartbeat, max_version);
-            node_digests.insert(ChitchatIdGenerationEq(chitchat_id), node_digest);
+            node_digests.insert(chitchat_id, node_digest);
         }
         Ok(Digest { node_digests })
     }
@@ -64,7 +63,7 @@ impl Serializable for Digest {
     fn serialized_len(&self) -> usize {
         let mut len = (self.node_digests.len() as u16).serialized_len();
         for (chitchat_id, node_digest) in &self.node_digests {
-            len += chitchat_id.0.serialized_len();
+            len += chitchat_id.serialized_len();
             len += node_digest.heartbeat.serialized_len();
             len += node_digest.max_version.serialized_len();
         }

--- a/chitchat/src/failure_detector.rs
+++ b/chitchat/src/failure_detector.rs
@@ -194,13 +194,13 @@ impl SamplingWindow {
 
     /// Computes the sampling window's phi value.
     pub fn phi(&self) -> f64 {
-        if self.last_heartbeat.is_none() {
+        if let Some(last_heartbeat) = self.last_heartbeat {
+            assert!(self.intervals.mean() > 0.0);
+            let elapsed_time = last_heartbeat.elapsed().as_secs_f64();
+            elapsed_time / self.intervals.mean()
+        } else {
             // if we phi is called before we have a sample, we assume the node isn't really alive.
             f64::INFINITY
-        } else {
-            assert!(self.intervals.mean() > 0.0);
-            let elapsed_time = self.last_heartbeat.unwrap().elapsed().as_secs_f64();
-            elapsed_time / self.intervals.mean()
         }
     }
 }

--- a/chitchat/src/lib.rs
+++ b/chitchat/src/lib.rs
@@ -86,8 +86,7 @@ impl Chitchat {
     }
 
     pub(crate) fn create_syn_message(&self) -> ChitchatMessage {
-        let dead_nodes: HashSet<_> = self.dead_nodes().collect();
-        let digest = self.compute_digest(&dead_nodes);
+        let digest = self.compute_digest();
         ChitchatMessage::Syn {
             cluster_id: self.config.cluster_id.clone(),
             digest,
@@ -107,7 +106,7 @@ impl Chitchat {
                 }
                 // Ensure for every reply from this node, at least the heartbeat is changed.
                 let dead_nodes: HashSet<_> = self.dead_nodes().collect();
-                let self_digest = self.compute_digest(&dead_nodes);
+                let self_digest = self.compute_digest();
                 let empty_delta = Delta::default();
                 let delta_mtu = MAX_UDP_DATAGRAM_PAYLOAD_SIZE
                     - syn_ack_serialized_len(&self_digest, &empty_delta);
@@ -168,6 +167,7 @@ impl Chitchat {
                 }
             } else {
                 self.failure_detector.report_unknown(chitchat_id);
+                self.failure_detector.update_node_liveness(chitchat_id);
             }
         }
     }
@@ -280,8 +280,8 @@ impl Chitchat {
     }
 
     /// Computes the node's digest.
-    fn compute_digest(&self, dead_nodes: &HashSet<&ChitchatId>) -> Digest {
-        self.cluster_state.compute_digest(dead_nodes)
+    fn compute_digest(&self) -> Digest {
+        self.cluster_state.compute_digest()
     }
 
     /// Subscribes a callback that will be called every time a key matching the supplied prefix

--- a/chitchat/src/lib.rs
+++ b/chitchat/src/lib.rs
@@ -166,6 +166,8 @@ impl Chitchat {
                 {
                     self.failure_detector.report_heartbeat(chitchat_id);
                 }
+            } else {
+                self.failure_detector.report_unknown(chitchat_id);
             }
         }
     }

--- a/chitchat/src/serialize.rs
+++ b/chitchat/src/serialize.rs
@@ -269,18 +269,9 @@ mod tests {
 
     #[test]
     fn test_serialize_chitchat_id() {
-        // we cant use test_serdeser_aux because ChitchatId isn't Eq
-        let obj = ChitchatId::new("node-id".to_string(), 1, "127.0.0.1:7280".parse().unwrap());
-        let num_bytes = 24;
-
-        let mut buf = Vec::new();
-        obj.serialize(&mut buf);
-        assert_eq!(buf.len(), obj.serialized_len());
-        assert_eq!(buf.len(), num_bytes);
-        let obj_serdeser = ChitchatId::deserialize(&mut &buf[..]).unwrap();
-        assert!(
-            obj.eq_generation(&obj_serdeser)
-                && obj.gossip_advertise_addr == obj_serdeser.gossip_advertise_addr
+        test_serdeser_aux(
+            &ChitchatId::new("node-id".to_string(), 1, "127.0.0.1:7280".parse().unwrap()),
+            24,
         );
     }
 

--- a/chitchat/src/server.rs
+++ b/chitchat/src/server.rs
@@ -594,11 +594,11 @@ mod tests {
         test_transport.send(server_addr, syn_ack).await.unwrap();
 
         // Wait for delta to ensure heartbeat key was incremented.
-        let (_, chitchat_message) = timeout(test_transport.recv()).await.unwrap();
-        let delta = if let ChitchatMessage::Ack { delta } = chitchat_message {
-            delta
-        } else {
-            panic!("Expected ack");
+        let delta = loop {
+            let (_, chitchat_message) = timeout(test_transport.recv()).await.unwrap();
+            if let ChitchatMessage::Ack { delta } = chitchat_message {
+                break delta;
+            };
         };
 
         let node_delta = &delta.node_deltas.get(&server_id).unwrap();

--- a/chitchat/src/server.rs
+++ b/chitchat/src/server.rs
@@ -260,17 +260,17 @@ impl Server {
 
         let peer_nodes = cluster_state
             .nodes()
-            .filter(|chitchat_id| !chitchat_id.eq_node_id(chitchat_guard.self_chitchat_id()))
+            .filter(|chitchat_id| *chitchat_id != chitchat_guard.self_chitchat_id())
             .map(|chitchat_id| chitchat_id.gossip_advertise_addr)
             .collect::<HashSet<_>>();
         let live_nodes = chitchat_guard
             .live_nodes()
-            .filter(|chitchat_id| !chitchat_id.eq_node_id(chitchat_guard.self_chitchat_id()))
+            .filter(|chitchat_id| *chitchat_id != chitchat_guard.self_chitchat_id())
             .map(|chitchat_id| chitchat_id.gossip_advertise_addr)
             .collect::<HashSet<_>>();
         let dead_nodes = chitchat_guard
             .dead_nodes()
-            .map(|chitchat_id| chitchat_id.0.gossip_advertise_addr)
+            .map(|chitchat_id| chitchat_id.gossip_advertise_addr)
             .collect::<HashSet<_>>();
         let seed_nodes: HashSet<SocketAddr> = chitchat_guard.seed_nodes();
         let (selected_nodes, random_dead_node_opt, random_seed_node_opt) = select_nodes_for_gossip(
@@ -416,7 +416,7 @@ mod tests {
     use super::*;
     use crate::message::ChitchatMessage;
     use crate::transport::{ChannelTransport, Transport};
-    use crate::{ChitchatIdGenerationEq, Heartbeat, NodeState, MAX_UDP_DATAGRAM_PAYLOAD_SIZE};
+    use crate::{Heartbeat, NodeState, MAX_UDP_DATAGRAM_PAYLOAD_SIZE};
 
     #[derive(Debug, Default)]
     struct RngForTest {
@@ -601,10 +601,7 @@ mod tests {
             panic!("Expected ack");
         };
 
-        let node_delta = &delta
-            .node_deltas
-            .get(&ChitchatIdGenerationEq(server_id))
-            .unwrap();
+        let node_delta = &delta.node_deltas.get(&server_id).unwrap();
         let heartbeat = node_delta.heartbeat;
         assert_eq!(heartbeat, Heartbeat(3));
 
@@ -631,7 +628,7 @@ mod tests {
         {
             let live_nodes = next_live_nodes(&mut live_nodes_watcher).await;
             assert_eq!(live_nodes.len(), 1);
-            assert!(live_nodes.contains_key(&ChitchatIdGenerationEq(node1_id)));
+            assert!(live_nodes.contains_key(&node1_id));
         }
         let mut node2_config = ChitchatConfig::for_test(6664);
         node2_config.seed_nodes = vec![node1_addr.to_string()];
@@ -642,18 +639,16 @@ mod tests {
         {
             let live_nodes = next_live_nodes(&mut live_nodes_watcher).await;
             assert_eq!(live_nodes.len(), 2);
-            assert!(live_nodes.contains_key(&ChitchatIdGenerationEq(node2_id)));
+            assert!(live_nodes.contains_key(&node2_id));
         }
 
         node1.shutdown().await.unwrap();
         node2.shutdown().await.unwrap();
     }
 
-    async fn next_live_nodes<
-        S: Unpin + Stream<Item = BTreeMap<ChitchatIdGenerationEq, NodeState>>,
-    >(
+    async fn next_live_nodes<S: Unpin + Stream<Item = BTreeMap<ChitchatId, NodeState>>>(
         watcher: &mut S,
-    ) -> BTreeMap<ChitchatIdGenerationEq, NodeState> {
+    ) -> BTreeMap<ChitchatId, NodeState> {
         tokio::time::timeout(Duration::from_secs(3), watcher.next())
             .await
             .expect("No Change within 3s")

--- a/chitchat/src/state.rs
+++ b/chitchat/src/state.rs
@@ -387,7 +387,7 @@ impl ClusterState {
                 // of max_version will be 0, and it may accept writes that are supposed to be
                 // stale, but it can tell they are.
                 if !delta_writer.add_kv(
-                    "",
+                    "__reset_sentinel",
                     VersionedValue {
                         value: String::new(),
                         version: stale_node.node_state.max_version,

--- a/chitchat/tests/cluster_test.rs
+++ b/chitchat/tests/cluster_test.rs
@@ -5,8 +5,7 @@ use std::time::Duration;
 use anyhow::anyhow;
 use chitchat::transport::ChannelTransport;
 use chitchat::{
-    spawn_chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, ChitchatIdGenerationEq,
-    FailureDetectorConfig, NodeState,
+    spawn_chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig, NodeState,
 };
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
@@ -67,7 +66,7 @@ impl NodeStatePredicate {
 
 struct Simulator {
     transport: ChannelTransport,
-    node_handles: HashMap<ChitchatIdGenerationEq, ChitchatHandle>,
+    node_handles: HashMap<ChitchatId, ChitchatHandle>,
     gossip_interval: Duration,
     marked_for_deletion_key_grace_period: usize,
 }
@@ -125,7 +124,7 @@ impl Simulator {
                     debug!(server_node_id=%server_chitchat_id.node_id, node_id=%chitchat_id.node_id, "node-state-assert");
                     let chitchat = self
                         .node_handles
-                        .get(&ChitchatIdGenerationEq(server_chitchat_id))
+                        .get(&server_chitchat_id)
                         .unwrap()
                         .chitchat();
                     // Wait for node_state & predicate.
@@ -174,11 +173,7 @@ impl Simulator {
         keys_values: Vec<(String, String)>,
     ) {
         debug!(node_id=%chitchat_id.node_id, num_keys_values=?keys_values.len(), "insert-keys-values");
-        let chitchat = self
-            .node_handles
-            .get(&ChitchatIdGenerationEq(chitchat_id))
-            .unwrap()
-            .chitchat();
+        let chitchat = self.node_handles.get(&chitchat_id).unwrap().chitchat();
         let mut chitchat_guard = chitchat.lock().await;
         for (key, value) in keys_values.into_iter() {
             chitchat_guard.self_node_state().set(key.clone(), value);
@@ -186,11 +181,7 @@ impl Simulator {
     }
 
     pub async fn mark_for_deletion(&mut self, chitchat_id: ChitchatId, key: String) {
-        let chitchat = self
-            .node_handles
-            .get(&ChitchatIdGenerationEq(chitchat_id.clone()))
-            .unwrap()
-            .chitchat();
+        let chitchat = self.node_handles.get(&chitchat_id).unwrap().chitchat();
         let mut chitchat_guard = chitchat.lock().await;
         chitchat_guard.self_node_state().mark_for_deletion(&key);
         let hearbeat = chitchat_guard.self_node_state().heartbeat();
@@ -207,7 +198,7 @@ impl Simulator {
             .unwrap_or_else(|| {
                 self.node_handles
                     .keys()
-                    .map(|id| id.0.clone())
+                    .cloned()
                     .collect::<Vec<ChitchatId>>()
             })
             .iter()
@@ -228,8 +219,7 @@ impl Simulator {
         let handle = spawn_chitchat(config, Vec::new(), &self.transport)
             .await
             .unwrap();
-        self.node_handles
-            .insert(ChitchatIdGenerationEq(chitchat_id), handle);
+        self.node_handles.insert(chitchat_id, handle);
     }
 }
 
@@ -481,7 +471,7 @@ async fn test_simple_simulation_heavy_insert_delete() {
     simulator.execute(add_node_operations).await;
 
     let key_names: Vec<_> = (0..200).map(|idx| format!("key_{}", idx)).collect();
-    let mut keys_values_inserted_per_chitchat_id: HashMap<ChitchatIdGenerationEq, HashSet<String>> =
+    let mut keys_values_inserted_per_chitchat_id: HashMap<ChitchatId, HashSet<String>> =
         HashMap::new();
     for chitchat_id in chitchat_ids.iter() {
         let mut keys_values = Vec::new();
@@ -489,7 +479,7 @@ async fn test_simple_simulation_heavy_insert_delete() {
             let value: u64 = rng.gen();
             keys_values.push((key.to_string(), value.to_string()));
             let keys_entry = keys_values_inserted_per_chitchat_id
-                .entry(ChitchatIdGenerationEq(chitchat_id.clone()))
+                .entry(chitchat_id.clone())
                 .or_default();
             keys_entry.insert(key.to_string());
         }
@@ -504,12 +494,12 @@ async fn test_simple_simulation_heavy_insert_delete() {
     tokio::time::sleep(Duration::from_secs(10)).await;
     info!("Checking keys are present...");
     for (chitchat_id, keys) in keys_values_inserted_per_chitchat_id.clone().into_iter() {
-        debug!(node_id=%chitchat_id.0.node_id, keys=?keys, "check");
+        debug!(node_id=%chitchat_id.node_id, keys=?keys, "check");
         for key in keys {
             let server_chitchat_id = chitchat_ids.choose(&mut rng).unwrap().clone();
             let check_operation = Operation::NodeStateAssert {
                 server_chitchat_id,
-                chitchat_id: chitchat_id.clone().0,
+                chitchat_id: chitchat_id.clone(),
                 predicate: NodeStatePredicate::KeyPresent(key.to_string(), true),
                 timeout_opt: None,
             };
@@ -521,7 +511,7 @@ async fn test_simple_simulation_heavy_insert_delete() {
     for (chitchat_id, keys) in keys_values_inserted_per_chitchat_id.clone().into_iter() {
         for key in keys {
             let check_operation = Operation::MarkKeyForDeletion {
-                chitchat_id: chitchat_id.clone().0,
+                chitchat_id: chitchat_id.clone(),
                 key,
             };
             simulator.execute(vec![check_operation]).await;
@@ -537,7 +527,7 @@ async fn test_simple_simulation_heavy_insert_delete() {
             let server_chitchat_id = chitchat_ids.choose(&mut rng).unwrap().clone();
             let check_operation = Operation::NodeStateAssert {
                 server_chitchat_id,
-                chitchat_id: chitchat_id.clone().0,
+                chitchat_id: chitchat_id.clone(),
                 predicate: NodeStatePredicate::KeyPresent(key.to_string(), false),
                 timeout_opt: None,
             };

--- a/chitchat/tests/cluster_test.rs
+++ b/chitchat/tests/cluster_test.rs
@@ -426,7 +426,7 @@ async fn test_marked_for_deletion_gc_with_network_partition() {
         },
         // Relink node 3
         Operation::AddNetworkLink(chitchat_id_1.clone(), chitchat_id_3.clone()),
-        Operation::AddNetworkLink(chitchat_id_1.clone(), chitchat_id_2.clone()),
+        Operation::AddNetworkLink(chitchat_id_2.clone(), chitchat_id_3.clone()),
         Operation::NodeStateAssert {
             server_chitchat_id: chitchat_id_3.clone(),
             chitchat_id: chitchat_id_1.clone(),

--- a/chitchat/tests/perf_test.rs
+++ b/chitchat/tests/perf_test.rs
@@ -4,8 +4,7 @@ use std::time::Duration;
 
 use chitchat::transport::{ChannelTransport, Transport, TransportExt};
 use chitchat::{
-    spawn_chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, ChitchatIdGenerationEq,
-    FailureDetectorConfig, NodeState,
+    spawn_chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig, NodeState,
 };
 use tokio::time::Instant;
 use tokio_stream::StreamExt;
@@ -43,7 +42,7 @@ async fn spawn_nodes(num_nodes: u16, transport: &dyn Transport) -> Vec<ChitchatH
     handles
 }
 
-async fn wait_until<P: Fn(&BTreeMap<ChitchatIdGenerationEq, NodeState>) -> bool>(
+async fn wait_until<P: Fn(&BTreeMap<ChitchatId, NodeState>) -> bool>(
     handle: &ChitchatHandle,
     predicate: P,
 ) -> Duration {

--- a/chitchat/tests/perf_test.rs
+++ b/chitchat/tests/perf_test.rs
@@ -109,7 +109,7 @@ async fn test_delay_before_dead_detection_100_faulty() {
     let _ = tracing_subscriber::fmt::try_init();
     let transport = ChannelTransport::with_mtu(65_507).drop_message(0.5f64);
     let delay = delay_before_detection_sample(100, &*transport).await;
-    assert!(delay < Duration::from_secs(10));
+    assert!(delay < Duration::from_secs(15));
 }
 
 async fn test_bandwidth_aux(num_nodes: usize) -> u64 {


### PR DESCRIPTION
fix #94 

I figured what was preventing gc.
- Node1 and Node2 communicate.
- Node2 dies.
- Node3 appears.
- Node1 isn't aware yet that Node2 is dead; it gives info about Node2 to Node3
- Node3 receives info of Node2, it record a heartbeat, but Node2 isn't in the state, so the failure detector actually doesn't record anything. Then the state is updated.
- Node1 and Node3 don't communicate about Node2 as nothing changed
- Node1 discovers Node2 is dead
- after some time, Node1 finally forget Node2
- Node3 notice Node1 haven't heard of Node2, and sends it the info
- Node1 receives info of Node2, it record a heartbeat, but Node2 isn't in the state, so the failure detector actually doesn't record anything. Then the state is updated.

Both Node1 and Node3 knows about Node2, but none track its state in their failure detector

what I implemented to fix that is that on first learning about a node, it's recorded in the failure detector as dead. if we get a 2nd heartbeat (with higher sequence number), we update to alive. That way a node in state should always be in the failure detector. We add it as dead because otherwise each time Node1 forget, the message from Node3 makes it believe that Node2 is alive, then Node3 forget, Node1 makes it believe Node2 is alive, then Node1 forget.... (this is only an issue if `dead_node_grace_period` can be smaller than the time it takes to detect a node is dead)

<br>
  
currently tests don't pass, and I have not been successful at fixing them. I left a comment with what I've figured so far at the place where it fails. Any help welcome!