### PR TITLE
Compression

### DIFF
--- a/chitchat/Cargo.toml
+++ b/chitchat/Cargo.toml
@@ -16,14 +16,22 @@ bytes = "1"
 itertools = "0.12"
 rand = { version = "0.8", features = ["small_rng"] }
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1.28.0", features = ["net", "sync", "rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.28.0", features = [
+    "net",
+    "sync",
+    "rt-multi-thread",
+    "macros",
+    "time",
+] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
+zstd = "0.13"
 
 [dev-dependencies]
 assert-json-diff = "2"
 mock_instant = "0.3"
 tracing-subscriber = "0.3"
+proptest = "1.4"
 
 [features]
 testsuite = []

--- a/chitchat/src/digest.rs
+++ b/chitchat/src/digest.rs
@@ -45,7 +45,18 @@ impl Serializable for Digest {
             node_digest.max_version.serialize(buf);
         }
     }
+    fn serialized_len(&self) -> usize {
+        let mut len = (self.node_digests.len() as u16).serialized_len();
+        for (chitchat_id, node_digest) in &self.node_digests {
+            len += chitchat_id.serialized_len();
+            len += node_digest.heartbeat.serialized_len();
+            len += node_digest.max_version.serialized_len();
+        }
+        len
+    }
+}
 
+impl Deserializable for Digest {
     fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
         let num_nodes = u16::deserialize(buf)?;
         let mut node_digests: BTreeMap<ChitchatId, NodeDigest> = Default::default();
@@ -58,15 +69,5 @@ impl Serializable for Digest {
             node_digests.insert(chitchat_id, node_digest);
         }
         Ok(Digest { node_digests })
-    }
-
-    fn serialized_len(&self) -> usize {
-        let mut len = (self.node_digests.len() as u16).serialized_len();
-        for (chitchat_id, node_digest) in &self.node_digests {
-            len += chitchat_id.serialized_len();
-            len += node_digest.heartbeat.serialized_len();
-            len += node_digest.max_version.serialized_len();
-        }
-        len
     }
 }

--- a/chitchat/src/serialize.rs
+++ b/chitchat/src/serialize.rs
@@ -1,7 +1,8 @@
 use std::io::BufRead;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
-use anyhow::bail;
+use anyhow::{bail, Context};
+use bytes::Buf;
 
 use crate::{ChitchatId, Heartbeat};
 
@@ -10,7 +11,7 @@ use crate::{ChitchatId, Heartbeat};
 /// Chitchat uses a custom binary serialization format.
 /// The point of this format is to make it possible
 /// to truncate the delta payload to a given mtu.
-pub trait Serializable: Sized {
+pub trait Serializable {
     fn serialize(&self, buf: &mut Vec<u8>);
 
     fn serialize_to_vec(&self) -> Vec<u8> {
@@ -19,9 +20,28 @@ pub trait Serializable: Sized {
         buf
     }
 
-    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self>;
-
     fn serialized_len(&self) -> usize;
+}
+
+pub trait Deserializable: Sized {
+    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self>;
+}
+
+impl Serializable for u8 {
+    fn serialize(&self, buf: &mut Vec<u8>) {
+        buf.push(*self)
+    }
+
+    fn serialized_len(&self) -> usize {
+        1
+    }
+}
+
+impl Deserializable for u8 {
+    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
+        let byte: [u8; 1] = Deserializable::deserialize(buf)?;
+        Ok(byte[0])
+    }
 }
 
 impl Serializable for u16 {
@@ -29,13 +49,32 @@ impl Serializable for u16 {
         self.to_le_bytes().serialize(buf);
     }
 
+    fn serialized_len(&self) -> usize {
+        2
+    }
+}
+
+impl Deserializable for u16 {
     fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
-        let u16_bytes: [u8; 2] = Serializable::deserialize(buf)?;
+        let u16_bytes: [u8; 2] = Deserializable::deserialize(buf)?;
         Ok(Self::from_le_bytes(u16_bytes))
+    }
+}
+
+impl Serializable for u32 {
+    fn serialize(&self, buf: &mut Vec<u8>) {
+        self.to_le_bytes().serialize(buf);
     }
 
     fn serialized_len(&self) -> usize {
-        2
+        4
+    }
+}
+
+impl Deserializable for u32 {
+    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
+        let u32_bytes: [u8; 4] = Deserializable::deserialize(buf)?;
+        Ok(Self::from_le_bytes(u32_bytes))
     }
 }
 
@@ -43,14 +82,14 @@ impl Serializable for u64 {
     fn serialize(&self, buf: &mut Vec<u8>) {
         self.to_le_bytes().serialize(buf);
     }
-
-    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
-        let u64_bytes: [u8; 8] = Serializable::deserialize(buf)?;
-        Ok(Self::from_le_bytes(u64_bytes))
-    }
-
     fn serialized_len(&self) -> usize {
         8
+    }
+}
+impl Deserializable for u64 {
+    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
+        let u64_bytes: [u8; 8] = Deserializable::deserialize(buf)?;
+        Ok(Self::from_le_bytes(u64_bytes))
     }
 }
 
@@ -61,16 +100,6 @@ impl Serializable for Option<u64> {
             tombstone.serialize(buf);
         }
     }
-
-    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
-        let is_some: bool = Serializable::deserialize(buf)?;
-        if is_some {
-            let u64_value = Serializable::deserialize(buf)?;
-            return Ok(Some(u64_value));
-        }
-        Ok(None)
-    }
-
     fn serialized_len(&self) -> usize {
         if self.is_some() {
             9
@@ -80,18 +109,30 @@ impl Serializable for Option<u64> {
     }
 }
 
+impl Deserializable for Option<u64> {
+    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
+        let is_some: bool = Deserializable::deserialize(buf)?;
+        if is_some {
+            let u64_value = Deserializable::deserialize(buf)?;
+            return Ok(Some(u64_value));
+        }
+        Ok(None)
+    }
+}
+
 impl Serializable for bool {
     fn serialize(&self, buf: &mut Vec<u8>) {
         buf.push(*self as u8);
     }
-
-    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
-        let bool_byte: [u8; 1] = Serializable::deserialize(buf)?;
-        Ok(bool_byte[0] != 0)
-    }
-
     fn serialized_len(&self) -> usize {
         1
+    }
+}
+
+impl Deserializable for bool {
+    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
+        let bool_byte: [u8; 1] = Deserializable::deserialize(buf)?;
+        Ok(bool_byte[0] != 0)
     }
 }
 
@@ -129,22 +170,6 @@ impl Serializable for IpAddr {
         }
     }
 
-    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
-        let ip_version_byte: [u8; 1] = Serializable::deserialize(buf)?;
-        let ip_version = IpVersion::try_from(ip_version_byte[0])?;
-
-        match ip_version {
-            IpVersion::V4 => {
-                let bytes: [u8; 4] = Serializable::deserialize(buf)?;
-                Ok(Ipv4Addr::from(bytes).into())
-            }
-            IpVersion::V6 => {
-                let bytes: [u8; 16] = Serializable::deserialize(buf)?;
-                Ok(Ipv6Addr::from(bytes).into())
-            }
-        }
-    }
-
     fn serialized_len(&self) -> usize {
         1 + match self {
             IpAddr::V4(_) => 4,
@@ -153,17 +178,46 @@ impl Serializable for IpAddr {
     }
 }
 
+impl Deserializable for IpAddr {
+    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
+        let ip_version_byte: [u8; 1] = Deserializable::deserialize(buf)?;
+        let ip_version = IpVersion::try_from(ip_version_byte[0])?;
+        match ip_version {
+            IpVersion::V4 => {
+                let bytes: [u8; 4] = Deserializable::deserialize(buf)?;
+                Ok(Ipv4Addr::from(bytes).into())
+            }
+            IpVersion::V6 => {
+                let bytes: [u8; 16] = Deserializable::deserialize(buf)?;
+                Ok(Ipv6Addr::from(bytes).into())
+            }
+        }
+    }
+}
+
 impl Serializable for String {
     fn serialize(&self, buf: &mut Vec<u8>) {
-        (self.len() as u16).serialize(buf);
-        buf.extend(self.as_bytes())
+        self.as_str().serialize(buf)
     }
 
+    fn serialized_len(&self) -> usize {
+        self.as_str().serialized_len()
+    }
+}
+
+impl Deserializable for String {
     fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
         let len: usize = u16::deserialize(buf)? as usize;
         let s = std::str::from_utf8(&buf[..len])?.to_string();
         buf.consume(len);
         Ok(s)
+    }
+}
+
+impl Serializable for str {
+    fn serialize(&self, buf: &mut Vec<u8>) {
+        (self.len() as u16).serialize(buf);
+        buf.extend(self.as_bytes())
     }
 
     fn serialized_len(&self) -> usize {
@@ -175,7 +229,12 @@ impl<const N: usize> Serializable for [u8; N] {
     fn serialize(&self, buf: &mut Vec<u8>) {
         buf.extend_from_slice(&self[..]);
     }
+    fn serialized_len(&self) -> usize {
+        N
+    }
+}
 
+impl<const N: usize> Deserializable for [u8; N] {
     fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
         if buf.len() < N {
             bail!("Buffer too short");
@@ -183,10 +242,6 @@ impl<const N: usize> Serializable for [u8; N] {
         let val_bytes: [u8; N] = buf[..N].try_into()?;
         buf.consume(N);
         Ok(val_bytes)
-    }
-
-    fn serialized_len(&self) -> usize {
-        N
     }
 }
 
@@ -196,14 +251,16 @@ impl Serializable for SocketAddr {
         self.port().serialize(buf);
     }
 
+    fn serialized_len(&self) -> usize {
+        self.ip().serialized_len() + self.port().serialized_len()
+    }
+}
+
+impl Deserializable for SocketAddr {
     fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
         let ip_addr = IpAddr::deserialize(buf)?;
         let port = u16::deserialize(buf)?;
         Ok(SocketAddr::new(ip_addr, port))
-    }
-
-    fn serialized_len(&self) -> usize {
-        self.ip().serialized_len() + self.port().serialized_len()
     }
 }
 
@@ -214,6 +271,14 @@ impl Serializable for ChitchatId {
         self.gossip_advertise_addr.serialize(buf)
     }
 
+    fn serialized_len(&self) -> usize {
+        self.node_id.serialized_len()
+            + self.generation_id.serialized_len()
+            + self.gossip_advertise_addr.serialized_len()
+    }
+}
+
+impl Deserializable for ChitchatId {
     fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
         let node_id = String::deserialize(buf)?;
         let generation_id = u64::deserialize(buf)?;
@@ -224,12 +289,6 @@ impl Serializable for ChitchatId {
             gossip_advertise_addr,
         })
     }
-
-    fn serialized_len(&self) -> usize {
-        self.node_id.serialized_len()
-            + self.generation_id.serialized_len()
-            + self.gossip_advertise_addr.serialized_len()
-    }
 }
 
 impl Serializable for Heartbeat {
@@ -237,19 +296,190 @@ impl Serializable for Heartbeat {
         self.0.serialize(buf);
     }
 
-    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
-        let heartbeat = u64::deserialize(buf)?;
-        Ok(Self(heartbeat))
-    }
-
     fn serialized_len(&self) -> usize {
         self.0.serialized_len()
     }
 }
 
+impl Deserializable for Heartbeat {
+    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
+        let heartbeat = u64::deserialize(buf)?;
+        Ok(Self(heartbeat))
+    }
+}
+
+/// A compressed stream writer receives a sequence of `Serializable` and
+/// serialize/compresses into blocks of a configurable size.
+///
+/// Block are tagged, so that blocks with a high entropy are stored kept "uncompressed".
+///
+/// The stream gives the client an upperbound of what the overall payload length would
+/// be if another item was appended.
+/// This makes it possible to enforce a `mtu`.
+pub struct CompressedStreamWriter {
+    output: Vec<u8>,
+    // temporary buffer used for block compression.
+    uncompressed_block: Vec<u8>,
+    // ongoing block being serialized.
+    compressed_block: Vec<u8>,
+    block_threshold: usize,
+}
+
+impl CompressedStreamWriter {
+    pub fn with_block_threshold(block_threshold: u16) -> CompressedStreamWriter {
+        let block_threshold = block_threshold as usize;
+        let output = Vec::with_capacity(block_threshold);
+        CompressedStreamWriter {
+            output,
+            uncompressed_block: Vec::with_capacity(block_threshold * 2),
+            compressed_block: Vec::with_capacity(block_threshold),
+            block_threshold,
+        }
+    }
+
+    /// Returns an upperbound of the serialized len after appending `s`
+    pub fn serialized_len_upperbound_after<S: Serializable + ?Sized>(&self, item: &S) -> usize {
+        let new_item_serialized_len = item.serialized_len();
+        assert!(new_item_serialized_len > 0);
+        const BLOCK_META_LEN: usize = 3;
+        let new_block_needed =
+            self.uncompressed_block.len() + new_item_serialized_len > self.block_threshold;
+        if new_block_needed {
+            BLOCK_META_LEN + self.output.len() + self.uncompressed_block.len() + // current block
+                BLOCK_META_LEN + new_item_serialized_len // new block
+                + 1 // No more blocks tag.
+        } else {
+            BLOCK_META_LEN + self.output.len() + self.uncompressed_block.len() + new_item_serialized_len // current block
+                + 1 // No more blocks tag.
+        }
+    }
+
+    /// Appends a new item to the stream. Items must be at most `u16::MAX` bytes long.
+    pub fn append<S: Serializable + ?Sized>(&mut self, item: &S) {
+        let item_len = item.serialized_len();
+        assert!(item_len <= u16::MAX as usize);
+        item.serialize(&mut self.uncompressed_block);
+        while self.uncompressed_block.len() > self.block_threshold {
+            // time to flush our current block.
+            self.flush_block();
+        }
+    }
+
+    /// Flush the first `block_threshold` bytes from the `uncompressed_block` buffer,
+    /// and remove them from the buffer.
+    ///
+    /// If the buffer less bytes than `block_threshold`, compress the bytes available.
+    /// (This happens for the last block.)
+    fn flush_block(&mut self) {
+        if self.uncompressed_block.is_empty() {
+            return;
+        }
+        let num_bytes_to_compress = self.uncompressed_block.len().min(self.block_threshold);
+
+        self.compressed_block.resize(num_bytes_to_compress, 0u8);
+        match zstd::bulk::compress_to_buffer(
+            &self.uncompressed_block[..num_bytes_to_compress],
+            &mut self.compressed_block[..],
+            0, // default compression level
+        ) {
+            Ok(compressed_len) => {
+                BlockType::Compressed.serialize(&mut self.output);
+                let compressed_len_u16 = u16::try_from(compressed_len).unwrap();
+                compressed_len_u16.serialize(&mut self.output);
+                self.output.extend(&self.compressed_block[..compressed_len]);
+            }
+            // The compressed version was actually longer than the decompressed one.
+            // Let's keep the block uncomopressed
+            Err(_) => {
+                BlockType::Uncompressed.serialize(&mut self.output);
+                let num_bytes_to_compress_u16 =
+                    u16::try_from(num_bytes_to_compress).expect("uncompressed block too big");
+                num_bytes_to_compress_u16.serialize(&mut self.output);
+                self.output
+                    .extend(&self.uncompressed_block[..num_bytes_to_compress]);
+            }
+        }
+        self.uncompressed_block.drain(..num_bytes_to_compress);
+    }
+
+    pub fn finish(mut self) -> Vec<u8> {
+        self.flush_block();
+        BlockType::NoMoreBlocks.serialize(&mut self.output);
+        self.output
+    }
+}
+
+pub fn deserialize_stream<D: Deserializable>(buf: &mut &[u8]) -> anyhow::Result<Vec<D>> {
+    let mut decompressed_data = Vec::new();
+    let mut decompressed_buffer = vec![0; u16::MAX as usize];
+    loop {
+        let block_type = BlockType::deserialize(buf)?;
+        match block_type {
+            BlockType::Compressed => {
+                let len = u16::deserialize(buf)? as usize;
+                let compressed_block_bytes = &buf[..len];
+                let uncompressed_len = zstd::bulk::decompress_to_buffer(
+                    compressed_block_bytes,
+                    &mut decompressed_buffer[..u16::MAX as usize],
+                )
+                .context("failed to decompress block")?;
+                buf.advance(len);
+                decompressed_data.extend_from_slice(&decompressed_buffer[..uncompressed_len]);
+            }
+            BlockType::Uncompressed => {
+                let len = u16::deserialize(buf)? as usize;
+                decompressed_data.extend_from_slice(&buf[..len]);
+                buf.advance(len);
+            }
+            BlockType::NoMoreBlocks => {
+                break;
+            }
+        }
+    }
+    let mut decompressed_cursor = &decompressed_data[..];
+    let mut items = Vec::new();
+    while !decompressed_cursor.is_empty() {
+        let item = D::deserialize(&mut decompressed_cursor)?;
+        items.push(item);
+    }
+    Ok(items)
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone)]
+enum BlockType {
+    NoMoreBlocks,
+    Compressed,
+    Uncompressed,
+}
+
+impl Serializable for BlockType {
+    fn serialize(&self, buf: &mut Vec<u8>) {
+        (*self as u8).serialize(buf)
+    }
+    fn serialized_len(&self) -> usize {
+        1
+    }
+}
+
+impl Deserializable for BlockType {
+    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
+        let byte = u8::deserialize(buf)?;
+        match byte {
+            0 => Ok(BlockType::NoMoreBlocks),
+            1 => Ok(BlockType::Compressed),
+            2 => Ok(BlockType::Uncompressed),
+            _ => anyhow::bail!("invalid block type"),
+        }
+    }
+}
+
 #[cfg(test)]
 #[track_caller]
-pub fn test_serdeser_aux<T: Serializable + PartialEq + std::fmt::Debug>(obj: &T, num_bytes: usize) {
+pub fn test_serdeser_aux<T: Serializable + Deserializable + PartialEq + std::fmt::Debug>(
+    obj: &T,
+    num_bytes: usize,
+) {
     let mut buf = Vec::new();
     obj.serialize(&mut buf);
     assert_eq!(buf.len(), obj.serialized_len());
@@ -260,6 +490,10 @@ pub fn test_serdeser_aux<T: Serializable + PartialEq + std::fmt::Debug>(obj: &T,
 
 #[cfg(test)]
 mod tests {
+    use proptest::proptest;
+    use rand::distributions::Alphanumeric;
+    use rand::Rng;
+
     use super::*;
 
     #[test]
@@ -295,5 +529,145 @@ mod tests {
     fn test_serialize_option_u64() {
         test_serdeser_aux(&Some(1), 9);
         test_serdeser_aux(&None, 1);
+    }
+
+    #[test]
+    fn test_serialize_block_type() {
+        let mut valid_vals_count = 0;
+        for b in 0..=u8::MAX {
+            if let Ok(block_type) = BlockType::deserialize(&mut &[b][..]) {
+                valid_vals_count += 1;
+                let serialized = block_type.serialize_to_vec();
+                assert_eq!(&serialized, &[b]);
+            }
+        }
+        assert_eq!(valid_vals_count, 3);
+    }
+
+    // An array of 10 small sentences for tests.
+    const TEXT_SAMPLES: [&str; 10] = [
+        "I'm happy.",
+        "She exercises every morning.",
+        "His dog barks loudly.",
+        "My school starts at 8:00.",
+        "We always eat dinner together.",
+        "They take the bus to work.",
+        "He doesn't like vegetables.",
+        "I don't want anything to drink.",
+        "hello Happy tax payer",
+        "do you like tea?",
+    ];
+
+    #[test]
+    fn test_compressed_serialized_stream() {
+        let mut compressed_stream_writer: CompressedStreamWriter =
+            CompressedStreamWriter::with_block_threshold(1_000);
+        let mut uncompressed_len = 0;
+        for i in 0..100 {
+            let sentence = TEXT_SAMPLES[i % TEXT_SAMPLES.len()];
+            compressed_stream_writer.append(sentence);
+            uncompressed_len += sentence.len();
+        }
+        let buf = compressed_stream_writer.finish();
+        let mut cursor = &buf[..];
+        assert!(buf.len() * 3 < uncompressed_len);
+        let vals: Vec<String> = super::deserialize_stream(&mut cursor).unwrap();
+        assert_eq!(vals.len(), 100);
+        for i in 0..100 {
+            let sentence = TEXT_SAMPLES[i % TEXT_SAMPLES.len()];
+            assert_eq!(&vals[i], sentence);
+        }
+        assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn test_compressed_serialized_stream_with_random_data() {
+        let mut compressed_stream_writer: CompressedStreamWriter =
+            CompressedStreamWriter::with_block_threshold(200);
+        for i in 0..100 {
+            let sentence = TEXT_SAMPLES[i % TEXT_SAMPLES.len()];
+            compressed_stream_writer.append(sentence);
+        }
+        for _ in 0..30 {
+            let rng = rand::thread_rng();
+            let random_sentence: String = rng
+                .sample_iter(&Alphanumeric)
+                .take(30)
+                .map(char::from)
+                .collect();
+            compressed_stream_writer.append(random_sentence.as_str());
+        }
+        let buf = compressed_stream_writer.finish();
+        let mut cursor = &buf[..];
+        let vals: Vec<String> = deserialize_stream(&mut cursor).unwrap();
+        assert_eq!(vals.len(), 130);
+        for i in 0..100 {
+            let sentence = TEXT_SAMPLES[i % TEXT_SAMPLES.len()];
+            assert_eq!(&vals[i], sentence);
+        }
+        assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn test_compressed_serialized_stream_len_when_there_are_no_compressed_blocks() {
+        {
+            let mut compressed_stream_writer: CompressedStreamWriter =
+                CompressedStreamWriter::with_block_threshold(10);
+            let random_string = "xu1Y3l";
+            let serialized_len_after_hello =
+                compressed_stream_writer.serialized_len_upperbound_after(random_string);
+            compressed_stream_writer.append(random_string);
+            let buffer = compressed_stream_writer.finish();
+            // There are no compression opportunity here. The foreseen serialized len should be the
+            // same as the actual length.
+            assert_eq!(buffer.len(), serialized_len_after_hello);
+        }
+        {
+            let mut compressed_stream_writer: CompressedStreamWriter =
+                CompressedStreamWriter::with_block_threshold(10);
+            let random_string = "pTs2yYd";
+            compressed_stream_writer.append(random_string);
+            let random_string2 = "vLQRFPN6";
+            let serialized_len_after_hello =
+                compressed_stream_writer.serialized_len_upperbound_after(random_string2);
+            compressed_stream_writer.append(random_string2);
+            let buffer = compressed_stream_writer.finish();
+            // There are no compression opportunity here. The foreseen serialized len should be the
+            // same as the actual length.
+            assert_eq!(buffer.len(), serialized_len_after_hello);
+        }
+    }
+
+    #[test]
+    fn test_empty() {
+        let mut compressed_stream_writer: CompressedStreamWriter =
+            CompressedStreamWriter::with_block_threshold(1_000);
+        let len_upper_bound = compressed_stream_writer.serialized_len_upperbound_after("");
+        compressed_stream_writer.append("");
+        let buf = compressed_stream_writer.finish();
+        let vals: Vec<String> = deserialize_stream(&mut &buf[..]).unwrap();
+        assert!(buf.len() <= len_upper_bound);
+        assert_eq!(vals.len(), 1);
+        assert_eq!(vals[0], "");
+    }
+
+    proptest! {
+        #[test]
+            fn test_proptest_compressed_stream(payload in proptest::collection::vec(".{0,1000}", 1..100)) {
+                let mut compressed_stream_writer: CompressedStreamWriter =
+                    CompressedStreamWriter::with_block_threshold(1_000);
+                for s in &payload[..payload.len() - 1] {
+                    compressed_stream_writer.append(s);
+                }
+                let len_upper_bound = compressed_stream_writer.serialized_len_upperbound_after(&payload[payload.len() - 1]);
+                compressed_stream_writer.append(&payload[payload.len() - 1]);
+                let buf = compressed_stream_writer.finish();
+                let vals: Vec<String> = deserialize_stream(&mut &buf[..]).unwrap();
+                assert!(buf.len() <= len_upper_bound);
+                assert_eq!(vals.len(), payload.len());
+                for (left, right) in vals.iter().zip(payload.iter()) {
+                    assert_eq!(left, right);
+                }
+            }
     }
 }

--- a/chitchat/src/server.rs
+++ b/chitchat/src/server.rs
@@ -601,7 +601,7 @@ mod tests {
             };
         };
 
-        let node_delta = &delta.node_deltas.get(&server_id).unwrap();
+        let node_delta = delta.get(&server_id).unwrap();
         let heartbeat = node_delta.heartbeat;
         assert_eq!(heartbeat, Heartbeat(3));
 

--- a/chitchat/src/transport/channel.rs
+++ b/chitchat/src/transport/channel.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::{bail, Context};
 use async_trait::async_trait;
 use tokio::sync::mpsc::{Receiver, Sender};
-use tracing::{debug, info};
+use tracing::info;
 
 use crate::serialize::Serializable;
 use crate::transport::{Socket, Transport};
@@ -98,7 +98,6 @@ impl ChannelTransport {
                 bail!("Serialized message size exceeds MTU.");
             }
         }
-        debug!(num_bytes = num_bytes, "send");
         let mut inner_lock = self.inner.lock().unwrap();
         inner_lock.statistics.record_message_len(num_bytes);
         if let Some(to_addrs) = inner_lock.removed_links.get(&from_addr) {

--- a/chitchat/src/transport/udp.rs
+++ b/chitchat/src/transport/udp.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use tracing::warn;
 
-use crate::serialize::Serializable;
+use crate::serialize::{Deserializable, Serializable};
 use crate::transport::{Socket, Transport};
 use crate::{ChitchatMessage, MAX_UDP_DATAGRAM_PAYLOAD_SIZE};
 

--- a/chitchat/tests/cluster_test.rs
+++ b/chitchat/tests/cluster_test.rs
@@ -9,7 +9,7 @@ use chitchat::{
 };
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 #[derive(Debug)]
 enum Operation {
@@ -158,7 +158,7 @@ impl Simulator {
                             }
                             assert!(predicate_value);
                         } else {
-                            info!(node_id=%chitchat_id.node_id, state_snapshot=?chitchat_guard.state_snapshot(), "Node state missing.");
+                            error!(node_id=%chitchat_id.node_id, state_snapshot=?chitchat_guard.state_snapshot(), "Node state missing.");
                             panic!("Node state missing");
                         }
                     }


### PR DESCRIPTION
    Adding ZSTD compression to chitchat's Deltas.

    The difficulty in this PR is coming from the fact that
    we need to observe the maximum transmissible unit,
    and due to the fact that we want to keep the simplficity
    of using the same `MessageDigest` object when
    sending and emitting messages.

    The solution I went for requires to compress things twice.
    When building our message object, we rely on a stream
    compressor that makes it possible to get an upperbound of the
    resulting payload after we insert an arbitrary serializable object.

    We then decompose the delta into as many mutations.

    I had to refactor the delta object, so that we have a proper bijection
    between a delta object and the list of mutations that were used to
    build it.

    The delta object hence encodes the order in which nodes, and values
    were inserted.
    The point there is to ensure that the actual serialization will
    yield the same size as the "simulated one" and hence respect the mtu.

    The code is a bit simpler that way too.
