### PR TITLE
Minor bugfix / refactoring.

### DIFF
--- a/chitchat/src/digest.rs
+++ b/chitchat/src/digest.rs
@@ -1,16 +1,16 @@
 use std::collections::BTreeMap;
 
 use crate::serialize::*;
-use crate::{ChitchatId, Heartbeat, MaxVersion};
+use crate::{ChitchatId, Heartbeat, Version};
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 pub(crate) struct NodeDigest {
     pub(crate) heartbeat: Heartbeat,
-    pub(crate) max_version: MaxVersion,
+    pub(crate) max_version: Version,
 }
 
 impl NodeDigest {
-    pub(crate) fn new(heartbeat: Heartbeat, max_version: MaxVersion) -> Self {
+    pub(crate) fn new(heartbeat: Heartbeat, max_version: Version) -> Self {
         Self {
             heartbeat,
             max_version,
@@ -30,7 +30,7 @@ pub struct Digest {
 
 #[cfg(test)]
 impl Digest {
-    pub fn add_node(&mut self, node: ChitchatId, heartbeat: Heartbeat, max_version: MaxVersion) {
+    pub fn add_node(&mut self, node: ChitchatId, heartbeat: Heartbeat, max_version: Version) {
         let node_digest = NodeDigest::new(heartbeat, max_version);
         self.node_digests.insert(node, node_digest);
     }

--- a/chitchat/src/state.rs
+++ b/chitchat/src/state.rs
@@ -15,14 +15,14 @@ use tracing::warn;
 use crate::delta::{Delta, DeltaWriter};
 use crate::digest::{Digest, NodeDigest};
 use crate::listener::Listeners;
-use crate::{ChitchatId, Heartbeat, KeyChangeEvent, MaxVersion, Version, VersionedValue};
+use crate::{ChitchatId, Heartbeat, KeyChangeEvent, Version, VersionedValue};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct NodeState {
     node_id: ChitchatId,
     heartbeat: Heartbeat,
     key_values: BTreeMap<String, VersionedValue>,
-    max_version: MaxVersion,
+    max_version: Version,
     #[serde(skip)]
     #[serde(default = "Instant::now")]
     last_heartbeat: Instant,
@@ -74,7 +74,7 @@ impl NodeState {
     }
 
     /// Returns the node's max version.
-    pub fn max_version(&self) -> MaxVersion {
+    pub fn max_version(&self) -> Version {
         self.max_version
     }
 
@@ -305,7 +305,6 @@ impl ClusterState {
                 node_state.heartbeat = node_delta.heartbeat;
                 node_state.last_heartbeat = Instant::now();
             }
-            node_state.max_version = node_state.max_version.max(node_delta.max_version);
             for (key, versioned_value) in node_delta.key_values {
                 node_state.max_version = node_state.max_version.max(versioned_value.version);
                 node_state.set_versioned_value(key, versioned_value);

--- a/chitchat/src/transport/udp.rs
+++ b/chitchat/src/transport/udp.rs
@@ -24,7 +24,7 @@ impl Transport for UdpTransport {
     }
 }
 
-struct UdpSocket {
+pub struct UdpSocket {
     buf_send: Vec<u8>,
     buf_recv: Box<[u8; MAX_UDP_DATAGRAM_PAYLOAD_SIZE]>,
     socket: tokio::net::UdpSocket,

--- a/chitchat/src/types.rs
+++ b/chitchat/src/types.rs
@@ -68,9 +68,6 @@ impl VersionedValue {
 /// The current version of a key.
 pub type Version = u64;
 
-/// The highest version of a key in a node's state.
-pub type MaxVersion = u64;
-
 /// The current heartbeat of a node.
 #[derive(
     Debug, Clone, Copy, Default, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize,

--- a/chitchat/tests/cluster_test.rs
+++ b/chitchat/tests/cluster_test.rs
@@ -326,6 +326,7 @@ async fn test_simple_simulation_with_network_partition() {
 
 #[tokio::test]
 async fn test_marked_for_deletion_gc_with_network_partition() {
+    const TIMEOUT: Duration = Duration::from_millis(500);
     // let _ = tracing_subscriber::fmt::try_init();
     let mut simulator = Simulator::new(Duration::from_millis(100), 10);
     let chitchat_id_1 = create_chitchat_id("node-1");
@@ -358,13 +359,13 @@ async fn test_marked_for_deletion_gc_with_network_partition() {
             server_chitchat_id: chitchat_id_2.clone(),
             chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), true),
-            timeout_opt: Some(Duration::from_millis(300)),
+            timeout_opt: Some(TIMEOUT),
         },
         Operation::NodeStateAssert {
             server_chitchat_id: chitchat_id_3.clone(),
             chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), true),
-            timeout_opt: Some(Duration::from_millis(300)),
+            timeout_opt: Some(TIMEOUT),
         },
         // Isolate node 3.
         Operation::RemoveNetworkLink(chitchat_id_1.clone(), chitchat_id_3.clone()),
@@ -379,7 +380,7 @@ async fn test_marked_for_deletion_gc_with_network_partition() {
             server_chitchat_id: chitchat_id_2.clone(),
             chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::MarkedForDeletion("key_a".to_string(), true),
-            timeout_opt: Some(Duration::from_millis(300)),
+            timeout_opt: Some(TIMEOUT),
         },
         // Check marked for deletion is not propagated to node 3.
         Operation::NodeStateAssert {
@@ -394,7 +395,7 @@ async fn test_marked_for_deletion_gc_with_network_partition() {
             server_chitchat_id: chitchat_id_2.clone(),
             chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), false),
-            timeout_opt: Some(Duration::from_millis(300)),
+            timeout_opt: Some(TIMEOUT),
         },
         Operation::NodeStateAssert {
             server_chitchat_id: chitchat_id_1.clone(),
@@ -411,7 +412,7 @@ async fn test_marked_for_deletion_gc_with_network_partition() {
         },
         // Wait for propagation
         // We need to wait longer... because node 4 is just starting?
-        Operation::Wait(Duration::from_millis(500)),
+        Operation::Wait(TIMEOUT),
         Operation::NodeStateAssert {
             server_chitchat_id: chitchat_id_3.clone(),
             chitchat_id: chitchat_id_1.clone(),
@@ -422,7 +423,7 @@ async fn test_marked_for_deletion_gc_with_network_partition() {
             server_chitchat_id: chitchat_id_4.clone(),
             chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), true),
-            timeout_opt: None,
+            timeout_opt: Some(TIMEOUT),
         },
         // Relink node 3
         Operation::AddNetworkLink(chitchat_id_1.clone(), chitchat_id_3.clone()),
@@ -431,13 +432,13 @@ async fn test_marked_for_deletion_gc_with_network_partition() {
             server_chitchat_id: chitchat_id_3.clone(),
             chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), false),
-            timeout_opt: Some(Duration::from_millis(500)),
+            timeout_opt: Some(TIMEOUT),
         },
         Operation::NodeStateAssert {
             server_chitchat_id: chitchat_id_4.clone(),
             chitchat_id: chitchat_id_1.clone(),
             predicate: NodeStatePredicate::KeyPresent("key_a".to_string(), false),
-            timeout_opt: Some(Duration::from_millis(500)),
+            timeout_opt: Some(TIMEOUT),
         },
     ];
     simulator.execute(operations).await;


### PR DESCRIPTION
- Bugfix: We were recording our own delta to report heartbeats. I did not dig but this was probably unconsequential: It was probably dismissed because it was not seen as an update.

- Simplification: After this PR, we only focus on heartbeat updates as a sign that a node was updated. As a result, we remove max_version from NodeDeltas. We also remove the MaxVersion type alias, that was pretty overkill.

- Unit test: attempt to fix a flaky test.

- Made UdpSocket public to remove a dynamic dispatch in quickwit.