### PR TITLE
Spreading KVs for half of the dead node grace period. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This crate is used at the core of Quickwit for
 - failure detection
 - sharing configuration, and extra metadata values
 
-The idea of relying on scuttlebutt reconciliation and phi-accrual detection is borrowed from
-Cassandra, itself borrowing it from DynamoDB.
+The idea of relying on scuttlebutt reconciliation and phi-accrual detection is borrowed from Cassandra, itself borrowing it from DynamoDB.
 
 A anti-entropy gossip algorithm called scuttlebutt is in charge of spreading
 a common state to all nodes.
@@ -28,6 +27,9 @@ Not receiving any update from node for a given amount of time can therefore be
 regarded as a sign of failure. Rather than using a hard threshold,
 we use phi-accrual detection to dynamically compute a threshold.
 
+We also abuse `chitchat` in Quickwit and use it like a reliable broadcast,
+with different caveats.
+
 # References
 
 - ScuttleButt paper: https://www.cs.cornell.edu/home/rvr/papers/flowgossip.pdf
@@ -36,3 +38,97 @@ we use phi-accrual detection to dynamically compute a threshold.
 https://www.youtube.com/watch?v=FuP1Fvrv6ZQ
 - https://docs.datastax.com/en/articles/cassandra/cassandrathenandnow.html
 - https://github.com/apache/cassandra/blob/f5fb1b0bd32b5dc7da13ec66d43acbdad7fe9dbf/src/java/org/apache/cassandra/gms/Gossiper.java#L1749
+
+# Heartbeat
+
+In order to get a constant flow of updates to feed into phi-accrual detection,
+chitchat's node state includes a key-value called `heartbeat`. The heartbeat of a given node,  starts at 0, and is incremented once after each round of gossip initiated.
+
+Nodes then report all heartbeat updates to a phi-accrual detector to
+assess the liveness of this node. Liveness is a local concept. Every single
+node computes its own vision of the liveness of all other nodes.
+
+# KV deletion
+
+The deletion of a KV is a just another type of mutation: it is
+associated with a version, and replicated using the same mechanism as a KV update.
+
+The library will then interpret this versioned tombstone before exposing kv to
+the user.
+
+To avoid keeping deleted KV indefinitely, the library includes a GC mechanism. Any nodes containing a tombstone older than a given `grace period threshold`
+(age is measured in ticks of heartbeat), it is safe to be deleted.
+
+This yields the following problem. If a node was disconnected for more than
+`marked_for_deletion_grace_period`, they could have missed the deletion of a KV and never be aware of it.
+
+To address this problem, nodes that are too outdated have to reset their state.
+
+More accurately, let's assume a Node A sends a Syn message to Node B with a digest with an outdated version V for a node N.
+Node B will compare the version of the digest with its own version.
+
+If V is fresher than `own version - marked_for_deletion_grace_period`,
+Node B knows that no GC has impacted Key values with a version above V. It can
+safely emit a normal delta to A.
+If however V is older than `own version - marked_for_deletion_grace_period`,
+a GC could have been executed. Instead of sending a delta to Node A, Node B will
+instruct A to reset its state.
+
+Node A will then wipe-off whatever information it has about N, and will start syncing from a blank state.
+
+# Node deletion
+
+In Quickwit, we also use chitchat as a "reliable broadcast with caveats".
+The idea of reliable broadcast is that the emission of a message is supposed
+to eventually be received by all or none of the correct nodes. Here, a node is called "correct" if it does not fail at any point during its execution.
+
+Of course, if the emitter starts failing before emitting its message, one cannot expect the message to reach anyone.
+However, if at least one correct nodes receives the message, it will
+eventually reach all correct nodes (assuming the node stays correct).
+
+For this reason, we keep emitting KVs from dead nodes too.
+
+To avoid keeping the state of dead nodes indefinitely, we make
+a very important trade off.
+
+If a node is marked as dead for more than `DEAD_NODE_GRACE_PERIOD`, we assume that its state can be safely removed from the system. The grace period is
+computed from the last time we received an update from the dead node.
+
+Just deleting the state is of course impossible. After the given `DEAD_NODE_GRACE_PERIOD / 2`, we will mark the dead node as `ScheduledForDeletion`.
+
+We first stop sharing data about nodes in the `ScheduledForDeletion` state,
+nor listing them node in our digest.
+
+We also ignore any updates received about the dead node. For simplification, we do not even keep track of the last update received. Eventually, all the nodes of the cluster will have marked the dead node as `ScheduledForDeletion`.
+
+After another `DEAD_NODE_GRACE_PERIOD` / 2 has elapsed since the last update received, we delete the dead node state.
+
+It is important to set `DEAD_NODE_GRACE_PERIOD` with a value such `DEAD_NODE_GRACE_PERIOD / 2` is much greater than the period it takes to detect a faulty node.
+
+Note that we are here breaking the reliable broadcast nature of chitchat.
+New nodes joining after `DEAD_NODE_GRACE_PERIOD` for instance, will never know about the state of the dead node.
+
+Also, if a node was disconnected from the cluster for more than `DEAD_NODE_GRACE_PERIOD / 2` and reconnects, it is likely to spread information
+about the dead node again. Worse, it could not know about the deletion
+of some specific KV and spread them again.
+
+The chitchat library does not include any mechanism to prevent this from happening. They should however eventually get deleted (after a bit more than `DEAD_NODE_GRACE_PERIOD`) if the node is really dead.
+
+If the node is alive, it should be able to fix everyone's state via reset or regular delta.
+
+<!--
+Alternative, more concise naming / explanation:
+
+Node deletion
+
+Heartbeats are fed into a phi-accrual detector.
+Detector tells live nodes from failed nodes apart.
+Failed nodes are GCed after GC_GRACE_PERIOD.
+Reliable broadcast
+
+In order to ensure reliable broadcast, we must propagate info about failed nodes for some time shorter than GC_GRACE_PERIOD before deleting them.
+To do so, failed nodes are split into two categories: zombie and dead.
+First, upon failure, failed nodes become zombie nodes, and we keep sharing data about them.
+After ZOMBIE_GRACE_PERIOD, zombie nodes transition to dead nodes, and we stop sharing data about them.
+ZOMBIE_GRACE_PERIOD is set to GC_GRACE_PERIOD / 2
+-->


### PR DESCRIPTION
See README for more information.

This change is made because we use chitchat as a reliable broadcast to
update published position in Quickwit.