### PR TITLE
Sample cluster state from peer seeds

### DIFF
--- a/chitchat/src/lib.rs
+++ b/chitchat/src/lib.rs
@@ -13,21 +13,29 @@ mod state;
 pub mod transport;
 mod types;
 
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter::once;
 use std::net::SocketAddr;
+use std::time::Duration;
 
+use anyhow::bail;
 use delta::Delta;
 use failure_detector::FailureDetector;
 pub use failure_detector::FailureDetectorConfig;
+use itertools::Itertools;
 pub use listener::ListenerHandle;
+use rand::seq::SliceRandom;
 pub use serialize::Serializable;
 use tokio::sync::watch;
+use tokio::time::timeout;
 use tokio_stream::wrappers::WatchStream;
 use tracing::{error, warn};
+use transport::Transport;
 
 pub use self::configuration::ChitchatConfig;
 pub use self::state::{ClusterStateSnapshot, NodeState};
+use crate::delta::DeltaSerializer;
 use crate::digest::Digest;
 pub use crate::message::ChitchatMessage;
 pub use crate::server::{spawn_chitchat, ChitchatHandle};
@@ -85,6 +93,77 @@ impl Chitchat {
         chitchat
     }
 
+    /// Gathers samples from the cluster state by connecting to the peer seeds in a random order
+    /// until `max_samples` are collected.
+    pub async fn sample_from_seeds(
+        &mut self,
+        transport: &dyn Transport,
+        gossip_listen_addr: SocketAddr,
+        max_samples: u16,
+        include_keys: Vec<String>,
+    ) -> anyhow::Result<HashMap<ChitchatId, HashMap<String, VersionedValue>>> {
+        // Using a random UDP port for one-time use.
+        let mut socket = transport
+            .open(SocketAddr::new(gossip_listen_addr.ip(), 0))
+            .await?;
+
+        let mut seed_addrs: Vec<SocketAddr> = self.cluster_state.seed_addrs().into_iter().collect();
+        seed_addrs.shuffle(&mut rand::thread_rng());
+
+        let mut node_states = HashMap::with_capacity(max_samples as usize);
+
+        for seed_addr in seed_addrs {
+            let sample_syn = ChitchatMessage::SampleSyn {
+                cluster_id: self.config.cluster_id.clone(),
+                max_samples,
+                include_keys: include_keys.clone(),
+            };
+            if let Err(io_error) = socket.send(seed_addr, sample_syn).await {
+                error!(error=%io_error, "failed to send sample SYN message");
+                continue;
+            }
+            let delta = match timeout(Duration::from_secs(5), socket.recv()).await {
+                Ok(Ok((_, ChitchatMessage::SampleAck { delta }))) => delta,
+                Ok(Ok((_, ChitchatMessage::BadCluster))) => bail!("bad cluster"),
+                Ok(Ok((_, chitchat_message))) => {
+                    panic!(
+                        "expected `SampleAck` or `BadCluster` message, got {:?}",
+                        chitchat_message
+                    )
+                }
+                Ok(Err(io_error)) => {
+                    error!(error=%io_error, "failed to receive sample ACK message");
+                    continue;
+                }
+                Err(_elapsed) => {
+                    warn!("timed out while waiting for sample ACK message");
+                    continue;
+                }
+            };
+            for node_delta in delta.node_deltas {
+                let node_state: &mut HashMap<String, VersionedValue> =
+                    node_states.entry(node_delta.chitchat_id).or_default();
+
+                for (key, value) in node_delta.key_values {
+                    match node_state.entry(key) {
+                        Entry::Vacant(vacant_entry) => {
+                            vacant_entry.insert(value);
+                        }
+                        Entry::Occupied(mut occupied_entry) => {
+                            if value.version > occupied_entry.get().version {
+                                occupied_entry.insert(value);
+                            }
+                        }
+                    }
+                }
+            }
+            if node_states.len() >= max_samples as usize {
+                break;
+            }
+        }
+        Ok(node_states)
+    }
+
     pub(crate) fn create_syn_message(&self) -> ChitchatMessage {
         let scheduled_for_deletion: HashSet<_> = self.scheduled_for_deletion_nodes().collect();
         let digest = self.compute_digest(&scheduled_for_deletion);
@@ -105,15 +184,17 @@ impl Chitchat {
     fn process_delta(&mut self, delta: Delta) {
         self.cluster_state.apply_delta(delta);
     }
+
     pub(crate) fn process_message(&mut self, msg: ChitchatMessage) -> Option<ChitchatMessage> {
         self.update_self_heartbeat();
+
         match msg {
             ChitchatMessage::Syn { cluster_id, digest } => {
                 if cluster_id != self.cluster_id() {
                     warn!(
                         our_cluster_id=%self.cluster_id(),
                         their_cluster_id=%cluster_id,
-                        "Received SYN message addressed to a different cluster."
+                        "received SYN message addressed to a different cluster"
                     );
                     return Some(ChitchatMessage::BadCluster);
                 }
@@ -149,7 +230,52 @@ impl Chitchat {
                 None
             }
             ChitchatMessage::BadCluster => {
-                warn!("Message rejected by peer: wrong cluster.");
+                warn!("message rejected by peer: wrong cluster");
+                None
+            }
+            ChitchatMessage::SampleSyn {
+                cluster_id,
+                max_samples,
+                include_keys,
+            } => {
+                if cluster_id != self.cluster_id() {
+                    warn!(
+                        our_cluster_id=%self.cluster_id(),
+                        their_cluster_id=%cluster_id,
+                        "received sample SYN message addressed to a different cluster"
+                    );
+                    return Some(ChitchatMessage::BadCluster);
+                }
+                let delta_mtu = MAX_UDP_DATAGRAM_PAYLOAD_SIZE - 1;
+                let mut delta_serializer = DeltaSerializer::with_mtu(delta_mtu);
+
+                // Sample live nodes with the highest heartbeat, which are the most likely to have
+                // up-to-date data.
+                for (chitchat_id, node_state) in self
+                    .live_nodes_watcher_rx
+                    .borrow()
+                    .iter()
+                    .sorted_unstable_by(|(_, left), (_, right)| {
+                        left.heartbeat().cmp(&right.heartbeat()).reverse()
+                    })
+                    .take(max_samples as usize)
+                {
+                    if !delta_serializer.try_add_node(chitchat_id.clone(), 0) {
+                        break;
+                    }
+                    for include_key in &include_keys {
+                        if let Some(value) = node_state.get_versioned(include_key) {
+                            if !delta_serializer.try_add_kv(include_key, value.clone()) {
+                                break;
+                            }
+                        }
+                    }
+                }
+                let delta = delta_serializer.finish();
+                Some(ChitchatMessage::SampleAck { delta })
+            }
+            ChitchatMessage::SampleAck { .. } => {
+                warn!("received unexpected sample ACK message");
                 None
             }
         }
@@ -270,6 +396,20 @@ impl Chitchat {
     /// Returns a serializable snapshot of the cluster state.
     pub fn state_snapshot(&self) -> ClusterStateSnapshot {
         ClusterStateSnapshot::from(&self.cluster_state)
+    }
+
+    pub fn insert_or_update_node(
+        &mut self,
+        chitchat_id: &ChitchatId,
+        key_values: impl Iterator<Item = (String, VersionedValue)>,
+    ) -> Version {
+        // TODO: How to insert in failure detector without reporting a heartbeat?
+        let node_state = self.cluster_state.node_state_mut(chitchat_id);
+
+        for (key, value) in key_values {
+            node_state.set_versioned_value(key, value)
+        }
+        node_state.max_version()
     }
 
     pub(crate) fn update_self_heartbeat(&mut self) {
@@ -828,5 +968,82 @@ mod tests {
 
         assert_eq!(counter_self_key.load(Ordering::SeqCst), 2);
         assert_eq!(counter_other_key.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_chitchat_sample() {
+        let transport = ChannelTransport::with_mtu(MAX_UDP_DATAGRAM_PAYLOAD_SIZE);
+        let ports = 12_001u16..=12_005;
+        let nodes = setup_nodes(ports.clone(), &transport).await;
+
+        for (idx, node) in nodes.iter().enumerate() {
+            node.with_chitchat(|chitchat| {
+                chitchat
+                    .self_node_state()
+                    .set("foo", format!("foo-value-{}", 12_001 + idx));
+                chitchat
+                    .self_node_state()
+                    .set("bar", format!("bar-value-{}", 12_001 + idx));
+            })
+            .await;
+        }
+
+        let node = nodes.first().unwrap();
+        let live_nodes_watcher = node.chitchat().lock().await.live_nodes_watcher();
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            live_nodes_watcher
+                .skip_while(|live_nodes| live_nodes.len() < nodes.len())
+                .next(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let ChitchatMessage::SampleAck { delta } = node
+            .with_chitchat(|chitchat| {
+                let sample_syn = ChitchatMessage::SampleSyn {
+                    cluster_id: "default-cluster".to_string(),
+                    max_samples: 3,
+                    include_keys: vec!["foo".to_string(), "qux".to_string()],
+                };
+                chitchat.process_message(sample_syn)
+            })
+            .await
+            .unwrap()
+        else {
+            panic!("expected `SampleAck` message");
+        };
+        assert_eq!(delta.node_deltas.len(), 3);
+
+        for node_delta in &delta.node_deltas {
+            assert_eq!(node_delta.key_values.len(), 1);
+            assert_eq!(node_delta.key_values[0].0, "foo");
+            assert_eq!(
+                node_delta.key_values[0].1.value,
+                format!("foo-value-{}", node_delta.chitchat_id.advertise_port())
+            );
+        }
+        // The first node has no seeds.
+        let node = nodes.last().unwrap();
+        let gossip_listen_addr: SocketAddr = "127.0.0.1:12000".parse().unwrap();
+        let node_states = node
+            .chitchat()
+            .lock()
+            .await
+            .sample_from_seeds(&transport, gossip_listen_addr, 3, vec!["foo".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(node_states.len(), 3);
+
+        for (chitchat_id, node_state) in node_states {
+            assert_eq!(node_state.len(), 1);
+            assert_eq!(
+                node_state.get("foo").unwrap().value,
+                format!("foo-value-{}", chitchat_id.advertise_port())
+            );
+        }
+        shutdown_nodes(nodes).await.unwrap();
     }
 }

--- a/chitchat/src/serialize.rs
+++ b/chitchat/src/serialize.rs
@@ -281,6 +281,40 @@ impl Deserializable for Heartbeat {
     }
 }
 
+impl<T> Serializable for Vec<T>
+where T: Serializable
+{
+    fn serialize(&self, buf: &mut Vec<u8>) {
+        assert!(self.len() <= u16::MAX as usize);
+
+        (self.len() as u16).serialize(buf);
+        for item in self {
+            item.serialize(buf);
+        }
+    }
+
+    fn serialized_len(&self) -> usize {
+        let mut len = 2;
+        for item in self {
+            len += item.serialized_len();
+        }
+        len
+    }
+}
+
+impl<T> Deserializable for Vec<T>
+where T: Deserializable
+{
+    fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self> {
+        let len = u16::deserialize(buf)? as usize;
+        let mut items = Vec::with_capacity(len);
+        for _ in 0..len {
+            items.push(T::deserialize(buf)?);
+        }
+        Ok(items)
+    }
+}
+
 /// A compressed stream writer receives a sequence of `Serializable` and
 /// serialize/compresses into blocks of a configurable size.
 ///
@@ -496,6 +530,15 @@ mod tests {
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
         ]));
         test_serdeser_aux(&ipv6, 17);
+    }
+
+    #[test]
+    fn test_serialize_vec() {
+        let empty_vec: Vec<String> = Vec::new();
+        test_serdeser_aux(&empty_vec, 2);
+
+        let foo_vec: Vec<String> = vec!["foo".to_string()];
+        test_serdeser_aux(&foo_vec, 7);
     }
 
     #[test]

--- a/chitchat/src/server.rs
+++ b/chitchat/src/server.rs
@@ -65,12 +65,12 @@ async fn resolve_seed_host(seed_host: &str, seed_addrs: &mut HashSet<SocketAddr>
         Ok(resolved_seed_addrs) => {
             for seed_addr in resolved_seed_addrs {
                 if seed_addrs.insert(seed_addr) {
-                    debug!(seed_host=%seed_host, seed_addr=%seed_addr, "Resolved peer seed host.");
+                    debug!(seed_host=%seed_host, seed_addr=%seed_addr, "resolved peer seed host");
                 }
             }
         }
         Err(error) => {
-            warn!(seed_host=%seed_host, error=?error, "Failed to lookup host.");
+            warn!(seed_host=%seed_host, error=?error, "failed to lookup host");
         }
     };
 }
@@ -202,7 +202,7 @@ impl Server {
         chitchat: Arc<Mutex<Chitchat>>,
         transport: Box<dyn Socket>,
     ) -> Self {
-        let rng = SmallRng::from_rng(thread_rng()).expect("Failed to seed random generator");
+        let rng = SmallRng::from_rng(thread_rng()).expect("failed to seed random generator");
         Self {
             chitchat,
             command_rx,

--- a/chitchat/src/state.rs
+++ b/chitchat/src/state.rs
@@ -20,7 +20,7 @@ use crate::{ChitchatId, Heartbeat, KeyChangeEvent, Version, VersionedValue};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct NodeState {
-    node_id: ChitchatId,
+    chitchat_id: ChitchatId,
     heartbeat: Heartbeat,
     key_values: BTreeMap<String, VersionedValue>,
     max_version: Version,
@@ -44,9 +44,9 @@ impl Debug for NodeState {
 }
 
 impl NodeState {
-    fn new(node_id: ChitchatId, listeners: Listeners) -> NodeState {
+    fn new(chitchat_id: ChitchatId, listeners: Listeners) -> NodeState {
         NodeState {
-            node_id,
+            chitchat_id,
             heartbeat: Heartbeat(0),
             key_values: Default::default(),
             max_version: 0u64,
@@ -57,7 +57,7 @@ impl NodeState {
 
     pub fn for_test() -> NodeState {
         NodeState {
-            node_id: ChitchatId {
+            chitchat_id: ChitchatId {
                 node_id: "test-node".to_string(),
                 generation_id: 0,
                 gossip_advertise_addr: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 7280),
@@ -212,17 +212,22 @@ impl NodeState {
     }
 
     /// Sets a new versioned value to associate to a given key.
-    /// This operation is ignored if  the key value inserted has a version that is obsolete.
+    /// This operation is ignored if the key value inserted has a version that is obsolete.
     ///
     /// This method also update the max_version if necessary.
-    fn set_versioned_value(&mut self, key: String, versioned_value_update: VersionedValue) {
+    pub(crate) fn set_versioned_value(
+        &mut self,
+        key: String,
+        versioned_value_update: VersionedValue,
+    ) {
         let key_clone = key.clone();
         let key_change_event = KeyChangeEvent {
             key: key_clone.as_str(),
             value: &versioned_value_update.value,
-            node: &self.node_id,
+            node: &self.chitchat_id,
         };
         self.max_version = versioned_value_update.version.max(self.max_version);
+
         match self.key_values.entry(key) {
             Entry::Occupied(mut occupied) => {
                 let occupied_versioned_value = occupied.get_mut();

--- a/chitchat/src/transport/udp.rs
+++ b/chitchat/src/transport/udp.rs
@@ -28,7 +28,7 @@ impl UdpSocket {
     pub async fn open(bind_addr: SocketAddr) -> anyhow::Result<UdpSocket> {
         let socket = tokio::net::UdpSocket::bind(bind_addr)
             .await
-            .with_context(|| format!("Failed to bind to {bind_addr}/UDP for gossip."))?;
+            .with_context(|| format!("failed to bind to {bind_addr}/UDP for gossip"))?;
         Ok(UdpSocket {
             buf_send: Vec::with_capacity(MAX_UDP_DATAGRAM_PAYLOAD_SIZE),
             buf_recv: Box::new([0u8; MAX_UDP_DATAGRAM_PAYLOAD_SIZE]),
@@ -81,7 +81,7 @@ impl UdpSocket {
         self.socket
             .send_to(payload, to_addr)
             .await
-            .context("Failed to send chitchat message to target")?;
+            .context("failed to send chitchat message to peer")?;
         Ok(())
     }
 }

--- a/chitchat/src/types.rs
+++ b/chitchat/src/types.rs
@@ -58,7 +58,34 @@ pub struct VersionedValue {
     pub version: Version,
     // The tombstone instant is transient:
     // Only the presence of a tombstone or not is serialized, and used in partial eq eq.
-    pub tombstone: Option<Instant>,
+    pub(crate) tombstone: Option<Instant>,
+}
+
+impl VersionedValue {
+    pub fn new(value: String, version: Version, is_tombstone: bool) -> VersionedValue {
+        VersionedValue {
+            value,
+            version,
+            tombstone: if is_tombstone {
+                Some(Instant::now())
+            } else {
+                None
+            },
+        }
+    }
+
+    pub fn is_tombstone(&self) -> bool {
+        self.tombstone.is_some()
+    }
+
+    #[cfg(test)]
+    pub fn for_test(value: &str, version: Version) -> Self {
+        Self {
+            value: value.to_string(),
+            version,
+            tombstone: None,
+        }
+    }
 }
 
 impl PartialEq for VersionedValue {
@@ -73,20 +100,16 @@ impl PartialEq for VersionedValue {
 struct VersionedValueForSerialization {
     pub value: String,
     pub version: Version,
-    pub tombstone: bool,
+    pub is_tombstone: bool,
 }
 
 impl From<VersionedValueForSerialization> for VersionedValue {
     fn from(versioned_value: VersionedValueForSerialization) -> Self {
-        VersionedValue {
-            value: versioned_value.value,
-            version: versioned_value.version,
-            tombstone: if versioned_value.tombstone {
-                Some(Instant::now())
-            } else {
-                None
-            },
-        }
+        VersionedValue::new(
+            versioned_value.value,
+            versioned_value.version,
+            versioned_value.is_tombstone,
+        )
     }
 }
 
@@ -95,18 +118,7 @@ impl From<VersionedValue> for VersionedValueForSerialization {
         VersionedValueForSerialization {
             value: versioned_value.value,
             version: versioned_value.version,
-            tombstone: versioned_value.tombstone.is_some(),
-        }
-    }
-}
-
-#[cfg(test)]
-impl VersionedValue {
-    pub fn for_test(value: &str, version: Version) -> Self {
-        Self {
-            value: value.to_string(),
-            version,
-            tombstone: None,
+            is_tombstone: versioned_value.tombstone.is_some(),
         }
     }
 }

--- a/chitchat/tests/cluster_test.rs
+++ b/chitchat/tests/cluster_test.rs
@@ -58,7 +58,7 @@ impl NodeStatePredicate {
             }
             NodeStatePredicate::MarkedForDeletion(key, marked) => {
                 debug!(key=%key, marked=marked, "assert-key-marked-for-deletion");
-                node_state.get_versioned(key).unwrap().tombstone.is_some() == *marked
+                node_state.get_versioned(key).unwrap().is_tombstone() == *marked
             }
         }
     }


### PR DESCRIPTION
The idea is to allow fetching a few attributes (readiness, gRPC advertise address) from the peer seeds using `sample_from_seeds` to then download the cluster state directly via gRPC calls, and finally bootstrap our own state using `insert_or_create_node`.