### PR TITLE
chitchat-test: allow mark for deletion and pretty-print json.

### DIFF
--- a/chitchat-test/README.md
+++ b/chitchat-test/README.md
@@ -8,9 +8,9 @@ to test the chitchat crate.
 
 ```bash
 # First server
-cargo run -- --listen_addr localhost:10000
+cargo run -- --listen_addr 127.0.0.1:10000
 # Second server
-cargo run -- --listen_addr localhost:10001 --seed localhost:10000
+cargo run -- --listen_addr 127.0.0.1:10001 --seed 127.0.0.1:10000
 ```
 
 ## Startup Flags that are optional 


### PR DESCRIPTION
Add ability to mark for deletion in chitchat-test.
Pretty-print the json output when displaying the chitchat state.
