### PR TITLE
Replace `return` with `warn!` in server loop

### DIFF
--- a/chitchat-test/run-servers.ps1
+++ b/chitchat-test/run-servers.ps1
@@ -1,0 +1,13 @@
+Get-Process "chitchat-test" | Stop-Process
+
+cargo build --release
+
+for ($i = 10000; $i -lt 10100; $i++)
+{
+    $listen_addr = "127.0.0.1:$i";
+    Write-Host $listen_addr;
+
+    Start-Process -NoNewWindow "cargo" -ArgumentList "run --release -- --listen_addr $listen_addr --seed 127.0.0.1:10002 --node_id node_$i"
+}
+
+Read-Host


### PR DESCRIPTION
The return causes the server to stop and all gossiping to end whenever a node leaves on windows. Each node which fails to communicate with the exited node will then stop gossiping.

Attempts to fix #145 