### PR TITLE
Avoid unstable const unwrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           key: ${{ runner.os }}-cargolint-${{ hashFiles('Cargo.lock') }}
       - name: rustfmt
         run: cargo +nightly fmt --all -- --check
+      - name: build with old rustc
+        run: make build-compat
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ license-check: check-license-tool
 license-fix: check-license-tool
 	dd-rust-license-tool write
 
+build-compat: fmt
+	@echo "Running `cargo build --package chitchat` with the min compatible Rust version"
+	@RUSTUP_TOOLCHAIN=1.70 cargo build --package chitchat
+
 fix: fmt
 	@echo "Running cargo clippy --fix"
 	@cargo clippy --fix --all-features --allow-dirty --allow-staged
@@ -20,5 +24,3 @@ fmt:
 
 test:
 	cargo test --release
-
-

--- a/chitchat/Cargo.toml
+++ b/chitchat/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 description = "Cluster membership library using gossip with Scuttlebutt reconciliation."
 repository = "https://github.com/quickwit-oss/chitchat"
+rust-version = "1.70"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/chitchat/src/lib.rs
+++ b/chitchat/src/lib.rs
@@ -49,7 +49,7 @@ pub(crate) const MAX_UDP_DATAGRAM_PAYLOAD_SIZE: usize = 65_507;
 /// To prevent dead nodes from being recorded again after deletion,
 /// we keep a local memory of the last nodes that were garbage collected.
 pub(crate) const GARBAGE_COLLECTED_NODE_HISTORY_SIZE: NonZeroUsize =
-    NonZeroUsize::new(500).unwrap();
+    unsafe { NonZeroUsize::new_unchecked(500) };
 
 pub struct Chitchat {
     config: ChitchatConfig,


### PR DESCRIPTION
Const panic is an unstable feature: https://rust-lang.github.io/rfcs/2345-const-panic.html

Quickwit CI fail: https://github.com/quickwit-oss/quickwit/actions/runs/13813433243/job/38640392942