### PR TITLE
Upgrade rust version and revert chitchat-test main deletion

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -7,22 +7,30 @@ ansi_term,https://github.com/ogham/rust-ansi-term,MIT,"ogham@bsago.me, Ryan Sche
 anstyle,https://github.com/rust-cli/anstyle,MIT OR Apache-2.0,The anstyle Authors
 anyhow,https://github.com/dtolnay/anyhow,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 async-trait,https://github.com/dtolnay/async-trait,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+atomic-waker,https://github.com/smol-rs/atomic-waker,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Contributors to futures-rs"
 atty,https://github.com/softprops/atty,MIT,softprops <d.tangren@gmail.com>
 backtrace,https://github.com/rust-lang/backtrace-rs,MIT OR Apache-2.0,The Rust Project Developers
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,Marshall Pierce <marshall@mpierce.org>
 bit-set,https://github.com/contain-rs/bit-set,Apache-2.0 OR MIT,Alexis Beingessner <a.beingessner@gmail.com>
 bit-vec,https://github.com/contain-rs/bit-vec,Apache-2.0 OR MIT,Alexis Beingessner <a.beingessner@gmail.com>
 bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project Developers
+block-buffer,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 bstr,https://github.com/BurntSushi/bstr,MIT OR Apache-2.0,Andrew Gallant <jamslam@gmail.com>
 bumpalo,https://github.com/fitzgen/bumpalo,MIT OR Apache-2.0,Nick Fitzgerald <fitzgen@gmail.com>
 bytes,https://github.com/tokio-rs/bytes,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 clap,https://github.com/clap-rs/clap,MIT,Kevin K. <kbknapp@gmail.com>
 cool-id-generator,https://github.com/PSeitz/cool-id-generator,MIT,"Pascal Seitz <pascal.seitz@sap.com>, mriise <mark.riise26@gmail.com>"
+cpufeatures,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
+crypto-common,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
+darling,https://github.com/TedDriggs/darling,MIT,Ted Driggs <ted.driggs@outlook.com>
+derive_more,https://github.com/JelteF/derive_more,MIT,Jelte Fennema <github-tech@jeltef.nl>
 difflib,https://github.com/DimaKudosh/difflib,MIT,Dima Kudosh <dimakudosh@gmail.com>
+digest,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 displaydoc,https://github.com/yaahc/displaydoc,MIT OR Apache-2.0,Jane Lusby <jlusby@yaah.dev>
 doc-comment,https://github.com/GuillaumeGomez/doc-comment,MIT,Guillaume Gomez <guillaume1.gomez@gmail.com>
 either,https://github.com/rayon-rs/either,MIT OR Apache-2.0,bluss
+encoding_rs,https://github.com/hsivonen/encoding_rs,(Apache-2.0 OR MIT) AND BSD-3-Clause,Henri Sivonen <hsivonen@hsivonen.fi>
 equivalent,https://github.com/indexmap-rs/equivalent,Apache-2.0 OR MIT,The equivalent Authors
 errno,https://github.com/lambda-fairy/rust-errno,MIT OR Apache-2.0,"Chris Wong <lambda.fairy@gmail.com>, Dan Gohman <dev@sunfishcode.online>"
 fastrand,https://github.com/smol-rs/fastrand,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
@@ -32,17 +40,22 @@ foldhash,https://github.com/orlp/foldhash,Zlib,Orson Peters <orsonpeters@gmail.c
 futures-channel,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-channel Authors
 futures-core,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-core Authors
 futures-io,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-io Authors
+futures-macro,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-macro Authors
 futures-sink,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-sink Authors
 futures-task,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-task Authors
 futures-util,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-util Authors
+generic-array,https://github.com/fizyk20/generic-array,MIT,"Bartłomiej Kamiński <fizyk20@gmail.com>, Aaron Trent <novacrazy@gmail.com>"
 getrandom,https://github.com/rust-random/getrandom,MIT OR Apache-2.0,The Rand Project Developers
 gimli,https://github.com/gimli-rs/gimli,MIT OR Apache-2.0,The gimli Authors
+h2,https://github.com/hyperium/h2,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
+headers,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.com>
 heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,Without Boats <woboats@gmail.com>
 hermit-abi,https://github.com/hermitcore/libhermit-rs,MIT OR Apache-2.0,Stefan Lankes
 http,https://github.com/hyperium/http,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 http-body,https://github.com/hyperium/http-body,MIT,"Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>"
 httparse,https://github.com/seanmonstar/httparse,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
+httpdate,https://github.com/pyfisch/httpdate,MIT OR Apache-2.0,Pyfisch <pyfisch@posteo.org>
 hyper,https://github.com/hyperium/hyper,MIT,Sean McArthur <sean@seanmonstar.com>
 hyper-util,https://github.com/hyperium/hyper-util,MIT,Sean McArthur <sean@seanmonstar.com>
 icu_collections,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
@@ -52,7 +65,10 @@ icu_normalizer_data,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X P
 icu_properties,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 icu_properties_data,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 icu_provider,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+ident_case,https://github.com/TedDriggs/ident_case,MIT OR Apache-2.0,Ted Driggs <ted.driggs@outlook.com>
 idna_adapter,https://github.com/hsivonen/idna_adapter,Apache-2.0 OR MIT,The rust-url developers
+indexmap,https://github.com/indexmap-rs/indexmap,Apache-2.0 OR MIT,The indexmap Authors
+io-uring,https://github.com/tokio-rs/io-uring,MIT OR Apache-2.0,quininer <quininer@live.com>
 ipnet,https://github.com/krisprice/ipnet,MIT OR Apache-2.0,Kris Price <kris@krisprice.nz>
 iri-string,https://github.com/lo48576/iri-string,MIT OR Apache-2.0,YOSHIOKA Takuma <nop_thread@nops.red>
 itertools,https://github.com/rust-itertools/itertools,MIT OR Apache-2.0,bluss
@@ -66,47 +82,61 @@ litemap,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Devel
 log,https://github.com/rust-lang/log,MIT OR Apache-2.0,The Rust Project Developers
 lru,https://github.com/jeromefroe/lru-rs,MIT,Jerome Froelich <jeromefroelic@hotmail.com>
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
+mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 miniz_oxide,https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide,MIT OR Zlib OR Apache-2.0,"Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com"
 mio,https://github.com/tokio-rs/mio,MIT,"Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>"
+multer,https://github.com/rwf2/multer,MIT,Rousan Ali <hello@rousan.io>
+nix,https://github.com/nix-rust/nix,MIT,The nix-rust Project Developers
 normalize-line-endings,https://github.com/derekdreery/normalize-line-endings,Apache-2.0,Richard Dodd <richdodj@gmail.com>
 nu-ansi-term,https://github.com/nushell/nu-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>, The Nushell Project Developers"
 num-traits,https://github.com/rust-num/num-traits,MIT OR Apache-2.0,The Rust Project Developers
 object,https://github.com/gimli-rs/object,Apache-2.0 OR MIT,The object Authors
 once_cell,https://github.com/matklad/once_cell,MIT OR Apache-2.0,Aleksey Kladov <aleksey.kladov@gmail.com>
 overload,https://github.com/danaugrs/overload,MIT,Daniel Salvadori <danaugrs@gmail.com>
+parking_lot,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,The pin-project-lite Authors
 pin-utils,https://github.com/rust-lang-nursery/pin-utils,MIT OR Apache-2.0,Josef Brandl <mail@josefbrandl.de>
+poem,https://github.com/poem-web/poem,MIT OR Apache-2.0,sunli <scott_s829@163.com>
 potential_utf,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,MIT OR Apache-2.0,The CryptoCorrosion Contributors
 predicates,https://github.com/assert-rs/predicates-rs,MIT OR Apache-2.0,Nick Stevens <nick@bitcurry.com>
 predicates-core,https://github.com/assert-rs/predicates-rs/tree/master/crates/core,MIT OR Apache-2.0,Nick Stevens <nick@bitcurry.com>
 predicates-tree,https://github.com/assert-rs/predicates-rs/tree/master/crates/tree,MIT OR Apache-2.0,Nick Stevens <nick@bitcurry.com>
+proc-macro-crate,https://github.com/bkchr/proc-macro-crate,MIT OR Apache-2.0,Bastian Köcher <git@kchr.de>
 proc-macro-error,https://gitlab.com/CreepySkeleton/proc-macro-error,MIT OR Apache-2.0,CreepySkeleton <creepy-skeleton@yandex.ru>
 proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>"
 quick-error,http://github.com/tailhook/quick-error,MIT OR Apache-2.0,"Paul Colomiets <paul@colomiets.name>, Colin Kiegel <kiegel@gmx.de>"
+quick-xml,https://github.com/tafia/quick-xml,MIT,The quick-xml Authors
 quote,https://github.com/dtolnay/quote,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 r-efi,https://github.com/r-efi/r-efi,MIT OR Apache-2.0 OR LGPL-2.1-or-later,The r-efi Authors
 rand,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_chacha,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers, The CryptoCorrosion Contributors"
 rand_xorshift,https://github.com/rust-random/rngs,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
+redox_syscall,https://gitlab.redox-os.org/redox-os/syscall,MIT,Jeremy Soller <jackpot51@gmail.com>
 regex,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regex-automata,https://github.com/rust-lang/regex/tree/master/regex-automata,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regex-syntax,https://github.com/rust-lang/regex/tree/master/regex-syntax,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
+rfc7239,https://github.com/icewind1991/rfc7239,MIT OR Apache-2.0,Robin Appelman <robin@icewind.nl>
 rustc-demangle,https://github.com/rust-lang/rustc-demangle,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 rustix,https://github.com/bytecodealliance/rustix,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,"Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>"
 rustversion,https://github.com/dtolnay/rustversion,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 rusty-fork,https://github.com/altsysrq/rusty-fork,MIT OR Apache-2.0,Jason Lingle
 ryu,https://github.com/dtolnay/ryu,Apache-2.0 OR BSL-1.0,David Tolnay <dtolnay@gmail.com>
+scopeguard,https://github.com/bluss/scopeguard,MIT OR Apache-2.0,bluss
 serde,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_json,https://github.com/serde-rs/json,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_urlencoded,https://github.com/nox/serde_urlencoded,MIT OR Apache-2.0,Anthony Ramine <n.oxyde@gmail.com>
+serde_yaml,https://github.com/dtolnay/serde-yaml,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+sha1,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sharded-slab,https://github.com/hawkw/sharded-slab,MIT,Eliza Weisman <eliza@buoyant.io>
 shlex,https://github.com/comex/rust-shlex,MIT OR Apache-2.0,"comex <comexk@gmail.com>, Fenhl <fenhl@fenhl.net>, Adrian Taylor <adetaylor@chromium.org>, Alex Touchet <alextouchet@outlook.com>, Daniel Parks <dp+git@oxidized.org>, Garrett Berg <googberg@gmail.com>"
 slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
 smallvec,https://github.com/servo/rust-smallvec,MIT OR Apache-2.0,The Servo Project Developers
 socket2,https://github.com/rust-lang/socket2,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>"
+spin,https://github.com/mvdnes/spin-rs,MIT,"Mathijs van de Nes <git@mathijs.vd-nes.nl>, John Ericson <git@JohnEricson.me>, Joshua Barretto <joshua.s.barretto@gmail.com>"
 stable_deref_trait,https://github.com/storyyeller/stable_deref_trait,MIT OR Apache-2.0,Robert Grosse <n210241048576@gmail.com>
 strsim,https://github.com/dguo/strsim-rs,MIT,Danny Guo <dannyguo91@gmail.com>
+strsim,https://github.com/rapidfuzz/strsim-rs,MIT,"Danny Guo <danny@dannyguo.com>, maxbachmann <oss@maxbachmann.de>"
 structopt,https://github.com/TeXitoi/structopt,Apache-2.0 OR MIT,"Guillaume Pinot <texitoi@texitoi.eu>, others"
 structopt-derive,https://github.com/TeXitoi/structopt,Apache-2.0 OR MIT,Guillaume Pinot <texitoi@texitoi.eu>
 syn,https://github.com/dtolnay/syn,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
@@ -115,9 +145,12 @@ synstructure,https://github.com/mystor/synstructure,MIT,Nika Layzell <nika@thela
 tempfile,https://github.com/Stebalien/tempfile,MIT OR Apache-2.0,"Steven Allen <steven@stebalien.com>, The Rust Project Developers, Ashley Mannix <ashleymannix@live.com.au>, Jason White <me@jasonwhite.io>"
 termtree,https://github.com/rust-cli/termtree,MIT,The termtree Authors
 textwrap,https://github.com/mgeisler/textwrap,MIT,Martin Geisler <martin@geisler.net>
+thiserror,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 thread_local,https://github.com/Amanieu/thread_local-rs,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 tinystr,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 tokio,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
+toml_datetime,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml_datetime Authors
+toml_edit,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml_edit Authors
 tower,https://github.com/tower-rs/tower,MIT,Tower Maintainers <team@tower-rs.com>
 tower-http,https://github.com/tower-rs/tower-http,MIT,Tower Maintainers <team@tower-rs.com>
 tracing,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, Tokio Contributors <team@tokio.rs>"
@@ -126,10 +159,14 @@ tracing-core,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@to
 tracing-log,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
 tracing-subscriber,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, David Barsky <me@davidbarsky.com>, Tokio Contributors <team@tokio.rs>"
 try-lock,https://github.com/seanmonstar/try-lock,MIT,Sean McArthur <sean@seanmonstar.com>
+typenum,https://github.com/paholg/typenum,MIT OR Apache-2.0,"Paho Lurie-Gregg <paho@paholg.com>, Andre Bogus <bogusandre@gmail.com>"
 unarray,https://github.com/cameron1024/unarray,MIT OR Apache-2.0,The unarray Authors
+uncased,https://github.com/SergioBenitez/uncased,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 unicode-ident,https://github.com/dtolnay/unicode-ident,(MIT OR Apache-2.0) AND Unicode-3.0,David Tolnay <dtolnay@gmail.com>
 unicode-segmentation,https://github.com/unicode-rs/unicode-segmentation,MIT OR Apache-2.0,"kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
 unicode-width,https://github.com/unicode-rs/unicode-width,MIT OR Apache-2.0,"kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
+unicode-xid,https://github.com/unicode-rs/unicode-xid,MIT OR Apache-2.0,"erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
+unsafe-libyaml,https://github.com/dtolnay/unsafe-libyaml,MIT,David Tolnay <dtolnay@gmail.com>
 url,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
 utf8_iter,https://github.com/hsivonen/utf8_iter,Apache-2.0 OR MIT,Henri Sivonen <hsivonen@hsivonen.fi>
 valuable,https://github.com/tokio-rs/valuable,MIT,The valuable Authors
@@ -145,6 +182,7 @@ wasm-bindgen-macro,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/m
 wasm-bindgen-macro-support,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support,MIT OR Apache-2.0,The wasm-bindgen Developers
 wasm-bindgen-shared,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared,MIT OR Apache-2.0,The wasm-bindgen Developers
 web-sys,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
+wildmatch,https://github.com/becheran/wildmatch,MIT,Armin Becher <armin.becher@gmail.com>
 winapi,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
 windows-sys,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
 windows-targets,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
@@ -156,6 +194,7 @@ windows_i686_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Micr
 windows_x86_64_gnu,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
 windows_x86_64_gnullvm,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
 windows_x86_64_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+winnow,https://github.com/winnow-rs/winnow,MIT,The winnow Authors
 wit-bindgen-rt,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,The wit-bindgen-rt Authors
 writeable,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 yoke,https://github.com/unicode-org/icu4x,Unicode-3.0,Manish Goregaokar <manishsmail@gmail.com>

--- a/chitchat-test/Cargo.toml
+++ b/chitchat-test/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "chitchat-test"
 version = "0.9.0"
-edition = "2021"
-rust-version = "1.82"
+edition = "2024"
+rust-version = "1.85"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 chitchat = { version = "0.9.0", path = "../chitchat" }
+poem = "3.1.11"
+poem-openapi = {version="5.1.15", features = ["swagger-ui"] }
 structopt = "0.3"
 tokio = { version = "1.28.0", features = ["net", "sync", "rt-multi-thread", "macros", "time"] }
 serde = { version="1", features=["derive"] }

--- a/chitchat-test/src/main.rs
+++ b/chitchat-test/src/main.rs
@@ -1,0 +1,127 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use chitchat::transport::UdpTransport;
+use chitchat::{Chitchat, ChitchatConfig, ChitchatId, FailureDetectorConfig, spawn_chitchat};
+use chitchat_test::{ApiResponse, SetKeyValueResponse};
+use cool_id_generator::Size;
+use poem::listener::TcpListener;
+use poem::{Route, Server};
+use poem_openapi::param::Query;
+use poem_openapi::payload::{Json, PlainText};
+use poem_openapi::{OpenApi, OpenApiService};
+use structopt::StructOpt;
+use tokio::sync::Mutex;
+
+struct Api {
+    chitchat: Arc<Mutex<Chitchat>>,
+}
+
+#[OpenApi]
+impl Api {
+    /// Chitchat state
+    #[oai(path = "/", method = "get")]
+    async fn index(&self) -> PlainText<String> {
+        let chitchat_guard = self.chitchat.lock().await;
+        let response = ApiResponse {
+            cluster_id: chitchat_guard.cluster_id().to_string(),
+            cluster_state: chitchat_guard.state_snapshot(),
+            live_nodes: chitchat_guard.live_nodes().cloned().collect::<Vec<_>>(),
+            dead_nodes: chitchat_guard.dead_nodes().cloned().collect::<Vec<_>>(),
+        };
+        PlainText(serde_json::to_string_pretty(&response).unwrap())
+    }
+
+    /// Sets a key-value pair on this node (without validation).
+    #[oai(path = "/set_kv/", method = "get")]
+    async fn set_kv(&self, key: Query<String>, value: Query<String>) -> Json<serde_json::Value> {
+        let mut chitchat_guard = self.chitchat.lock().await;
+
+        let cc_state = chitchat_guard.self_node_state();
+        cc_state.set(key.as_str(), value.as_str());
+
+        Json(serde_json::to_value(&SetKeyValueResponse { status: true }).unwrap())
+    }
+
+    /// Marks a key for deletion on this node (without validation).
+    #[oai(path = "/mark_for_deletion/", method = "get")]
+    async fn mark_for_deletion(&self, key: Query<String>) -> Json<serde_json::Value> {
+        let mut chitchat_guard = self.chitchat.lock().await;
+
+        let cc_state = chitchat_guard.self_node_state();
+        cc_state.delete(key.as_str());
+        Json(serde_json::to_value(&SetKeyValueResponse { status: true }).unwrap())
+    }
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "chitchat", about = "Chitchat test server.")]
+struct Opt {
+    /// Defines the socket addr on which we should listen to.
+    #[structopt(long = "listen_addr", default_value = "127.0.0.1:10000")]
+    listen_addr: SocketAddr,
+    /// Defines the socket address (host:port) other servers should use to
+    /// reach this server.
+    ///
+    /// It defaults to the listen address, but this is only valid
+    /// when all server are running on the same server.
+    #[structopt(long = "public_addr")]
+    public_addr: Option<SocketAddr>,
+
+    /// Node ID. Must be unique. If None, the node ID will be generated from
+    /// the public_addr and a random suffix.
+    #[structopt(long = "node_id")]
+    node_id: Option<String>,
+
+    #[structopt(long = "seed")]
+    seeds: Vec<String>,
+
+    #[structopt(long = "interval_ms", default_value = "500")]
+    interval: u64,
+}
+
+fn generate_server_id(public_addr: SocketAddr) -> String {
+    let cool_id = cool_id_generator::get_id(Size::Medium);
+    format!("server:{public_addr}-{cool_id}")
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let opt = Opt::from_args();
+    let public_addr = opt.public_addr.unwrap_or(opt.listen_addr);
+    let node_id = opt
+        .node_id
+        .unwrap_or_else(|| generate_server_id(public_addr));
+    let generation = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let chitchat_id = ChitchatId::new(node_id, generation, public_addr);
+    let config = ChitchatConfig {
+        cluster_id: "testing".to_string(),
+        chitchat_id,
+        gossip_interval: Duration::from_millis(opt.interval),
+        listen_addr: opt.listen_addr,
+        seed_nodes: opt.seeds.clone(),
+        failure_detector_config: FailureDetectorConfig {
+            dead_node_grace_period: Duration::from_secs(10),
+            ..FailureDetectorConfig::default()
+        },
+        marked_for_deletion_grace_period: Duration::from_secs(60),
+        catchup_callback: None,
+        extra_liveness_predicate: None,
+    };
+    let chitchat_handler = spawn_chitchat(config, Vec::new(), &UdpTransport).await?;
+    let chitchat = chitchat_handler.chitchat();
+    let api = Api { chitchat };
+    let api_service = OpenApiService::new(api, "Hello World", "1.0")
+        .server(format!("http://{}/", opt.listen_addr));
+    let docs = api_service.swagger_ui();
+    let app = Route::new().nest("/", api_service).nest("/docs", docs);
+    Server::new(TcpListener::bind(&opt.listen_addr))
+        .run(app)
+        .await?;
+    Ok(())
+}

--- a/chitchat/Cargo.toml
+++ b/chitchat/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "chitchat"
 version = "0.9.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 description = "Cluster membership library using gossip with Scuttlebutt reconciliation."
 repository = "https://github.com/quickwit-oss/chitchat"
-rust-version = "1.82"
+rust-version = "1.85"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/chitchat/src/delta.rs
+++ b/chitchat/src/delta.rs
@@ -250,10 +250,12 @@ impl Delta {
         last_gc_version: Version,
         from_version: Version,
     ) {
-        assert!(!self
-            .node_deltas
-            .iter()
-            .any(|node_delta| { node_delta.chitchat_id == chitchat_id }));
+        assert!(
+            !self
+                .node_deltas
+                .iter()
+                .any(|node_delta| { node_delta.chitchat_id == chitchat_id })
+        );
         self.node_deltas.push(NodeDelta {
             chitchat_id,
             last_gc_version,

--- a/chitchat/src/failure_detector.rs
+++ b/chitchat/src/failure_detector.rs
@@ -316,8 +316,8 @@ mod tests {
     use rand::prelude::*;
 
     use super::{BoundedArrayStats, SamplingWindow};
-    use crate::failure_detector::{FailureDetector, FailureDetectorConfig};
     use crate::ChitchatId;
+    use crate::failure_detector::{FailureDetector, FailureDetectorConfig};
 
     impl FailureDetector {
         pub fn contains_node(&self, chitchat_id: &ChitchatId) -> bool {

--- a/chitchat/src/message.rs
+++ b/chitchat/src/message.rs
@@ -1,6 +1,6 @@
 use std::io::BufRead;
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 
 use crate::delta::Delta;
 use crate::digest::Digest;

--- a/chitchat/src/serialize.rs
+++ b/chitchat/src/serialize.rs
@@ -1,7 +1,7 @@
 use std::io::BufRead;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use bytes::Buf;
 
 use crate::{ChitchatId, Heartbeat};
@@ -475,8 +475,8 @@ pub fn test_serdeser_aux<T: Serializable + Deserializable + PartialEq + std::fmt
 #[cfg(test)]
 mod tests {
     use proptest::proptest;
-    use rand::distr::Alphanumeric;
     use rand::Rng;
+    use rand::distr::Alphanumeric;
 
     use super::*;
 

--- a/chitchat/src/server.rs
+++ b/chitchat/src/server.rs
@@ -8,7 +8,7 @@ use rand::prelude::*;
 use rand::rng;
 use tokio::net::lookup_host;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use tokio::sync::{watch, Mutex};
+use tokio::sync::{Mutex, watch};
 use tokio::task::JoinHandle;
 use tokio::time;
 use tracing::{debug, info, warn};
@@ -447,7 +447,7 @@ mod tests {
     use super::*;
     use crate::message::ChitchatMessage;
     use crate::transport::{ChannelTransport, Transport};
-    use crate::{Heartbeat, NodeState, MAX_UDP_DATAGRAM_PAYLOAD_SIZE};
+    use crate::{Heartbeat, MAX_UDP_DATAGRAM_PAYLOAD_SIZE, NodeState};
 
     #[derive(Debug, Default)]
     struct RngForTest {

--- a/chitchat/src/state.rs
+++ b/chitchat/src/state.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 
 use itertools::Itertools;
 use lru::LruCache;
-use rand::prelude::SliceRandom;
 use rand::Rng;
+use rand::prelude::SliceRandom;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use tokio::time::Instant;
@@ -20,8 +20,8 @@ use crate::digest::{Digest, NodeDigest};
 use crate::listener::Listeners;
 use crate::types::{DeletionStatus, DeletionStatusMutation};
 use crate::{
-    ChitchatId, Heartbeat, KeyChangeEvent, Version, VersionedValue,
-    GARBAGE_COLLECTED_NODE_HISTORY_SIZE,
+    ChitchatId, GARBAGE_COLLECTED_NODE_HISTORY_SIZE, Heartbeat, KeyChangeEvent, Version,
+    VersionedValue,
 };
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -851,17 +851,17 @@ fn random_generator() -> impl Rng {
 // We use a deterministic random generator in tests.
 #[cfg(test)]
 fn random_generator() -> impl Rng {
-    use rand::prelude::StdRng;
     use rand::SeedableRng;
+    use rand::prelude::StdRng;
     StdRng::seed_from_u64(9u64)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::MAX_UDP_DATAGRAM_PAYLOAD_SIZE;
     use crate::serialize::Serializable;
     use crate::types::{DeletionStatusMutation, KeyValueMutation};
-    use crate::MAX_UDP_DATAGRAM_PAYLOAD_SIZE;
 
     #[test]
     fn test_stale_node_iter_stale_key_values() {
@@ -1136,10 +1136,12 @@ mod tests {
             assert_eq!(&versioned_value.value, "");
             assert_eq!(versioned_value.version, 2u64);
             assert!(versioned_value.is_deleted());
-            assert!(versioned_value
-                .status
-                .time_of_start_scheduled_for_deletion()
-                .is_some());
+            assert!(
+                versioned_value
+                    .status
+                    .time_of_start_scheduled_for_deletion()
+                    .is_some()
+            );
         }
 
         // Overriding the same key
@@ -1149,10 +1151,12 @@ mod tests {
             assert_eq!(&versioned_value.value, "2");
             assert_eq!(versioned_value.version, 3u64);
             assert!(!versioned_value.is_deleted());
-            assert!(versioned_value
-                .status
-                .time_of_start_scheduled_for_deletion()
-                .is_none());
+            assert!(
+                versioned_value
+                    .status
+                    .time_of_start_scheduled_for_deletion()
+                    .is_none()
+            );
         }
     }
 
@@ -1169,10 +1173,12 @@ mod tests {
             let versioned_value = node_state.get_versioned("key").unwrap();
             assert_eq!(&versioned_value.value, "1");
             assert_eq!(versioned_value.version, 2u64);
-            assert!(versioned_value
-                .status
-                .time_of_start_scheduled_for_deletion()
-                .is_some());
+            assert!(
+                versioned_value
+                    .status
+                    .time_of_start_scheduled_for_deletion()
+                    .is_some()
+            );
             assert!(!versioned_value.is_deleted());
             assert!(matches!(
                 versioned_value.status,
@@ -1187,10 +1193,12 @@ mod tests {
             assert_eq!(&versioned_value.value, "2");
             assert_eq!(versioned_value.version, 3u64);
             assert!(!versioned_value.is_deleted());
-            assert!(versioned_value
-                .status
-                .time_of_start_scheduled_for_deletion()
-                .is_none());
+            assert!(
+                versioned_value
+                    .status
+                    .time_of_start_scheduled_for_deletion()
+                    .is_none()
+            );
             assert!(matches!(versioned_value.status, DeletionStatus::Set));
         }
     }
@@ -1247,11 +1255,13 @@ mod tests {
         // GC if tombstone (=100) + grace_period > heartbeat (=110).
         tokio::time::advance(Duration::from_secs(5)).await;
         cluster_state.gc_keys_marked_for_deletion(Duration::from_secs(10));
-        assert!(!cluster_state
-            .node_state(&node1)
-            .unwrap()
-            .key_values
-            .contains_key("key_a"));
+        assert!(
+            !cluster_state
+                .node_state(&node1)
+                .unwrap()
+                .key_values
+                .contains_key("key_a")
+        );
         cluster_state
             .node_state(&node1)
             .unwrap()

--- a/chitchat/src/transport/channel.rs
+++ b/chitchat/src/transport/channel.rs
@@ -2,14 +2,14 @@ use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use async_trait::async_trait;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::info;
 
+use crate::ChitchatMessage;
 use crate::serialize::{Deserializable, Serializable};
 use crate::transport::{Socket, Transport};
-use crate::ChitchatMessage;
 
 const MAX_MESSAGE_PER_CHANNEL: usize = 100;
 

--- a/chitchat/src/transport/mod.rs
+++ b/chitchat/src/transport/mod.rs
@@ -36,11 +36,11 @@ mod tests {
     use tokio::time::timeout;
 
     use super::Transport;
+    use crate::MAX_UDP_DATAGRAM_PAYLOAD_SIZE;
     use crate::digest::Digest;
     use crate::message::ChitchatMessage;
     use crate::serialize::Serializable;
     use crate::transport::{ChannelTransport, UdpTransport};
-    use crate::MAX_UDP_DATAGRAM_PAYLOAD_SIZE;
 
     fn sample_syn_msg() -> ChitchatMessage {
         ChitchatMessage::Syn {
@@ -83,9 +83,11 @@ mod tests {
         let addr2: SocketAddr = ([127, 0, 0, 1], 20_002u16).into();
         let mut socket1 = transport.open(addr1).await.unwrap();
         let mut socket2 = transport.open(addr2).await.unwrap();
-        assert!(timeout(Duration::from_millis(200), socket2.recv())
-            .await
-            .is_err());
+        assert!(
+            timeout(Duration::from_millis(200), socket2.recv())
+                .await
+                .is_err()
+        );
         let syn_message = sample_syn_msg();
         let socket_recv_fut = tokio::task::spawn(async move { socket2.recv().await.unwrap() });
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/chitchat/src/transport/utils.rs
+++ b/chitchat/src/transport/utils.rs
@@ -5,11 +5,11 @@ use std::time::Duration;
 use async_trait::async_trait;
 use rand::distr::Bernoulli;
 use rand::prelude::{Distribution, SmallRng};
-use rand::{rng, SeedableRng};
+use rand::{SeedableRng, rng};
 use tokio::sync::RwLock;
 
-use crate::transport::{Socket, Transport};
 use crate::ChitchatMessage;
+use crate::transport::{Socket, Transport};
 
 struct TransportWithDelay<D: Distribution<f32> + Send + Sync + 'static> {
     delay_secs: D,

--- a/chitchat/src/types.rs
+++ b/chitchat/src/types.rs
@@ -4,8 +4,8 @@ use std::net::SocketAddr;
 use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
 
-use crate::serialize::Deserializable;
 use crate::Serializable;
+use crate::serialize::Deserializable;
 
 /// For the lifetime of a cluster, nodes can go down and come back up multiple times. They may also
 /// die permanently. A [`ChitchatId`] is composed of three components:

--- a/chitchat/tests/cluster_test.rs
+++ b/chitchat/tests/cluster_test.rs
@@ -6,12 +6,12 @@ use std::time::Duration;
 use anyhow::anyhow;
 use chitchat::transport::ChannelTransport;
 use chitchat::{
-    spawn_chitchat, Chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig,
-    NodeState,
+    Chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig, NodeState,
+    spawn_chitchat,
 };
 use itertools::Itertools;
 use rand::prelude::IndexedRandom;
-use rand::{rng, Rng};
+use rand::{Rng, rng};
 use tracing::{debug, error, info};
 
 #[derive(Debug)]

--- a/chitchat/tests/perf_test.rs
+++ b/chitchat/tests/perf_test.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use chitchat::transport::{ChannelTransport, Transport, TransportExt};
 use chitchat::{
-    spawn_chitchat, ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig, NodeState,
+    ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig, NodeState, spawn_chitchat,
 };
 use tokio::time::Instant;
 use tokio_stream::StreamExt;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-channel = "1.82"
+channel = "1.85"
 components = ["cargo", "clippy", "rustfmt", "rust-docs"]
-


### PR DESCRIPTION
This is the alternative to removing the chitchat-test package altogether (https://github.com/quickwit-oss/chitchat/pull/163)