### PR TITLE
Make the deserializable trait public to align with the transport module

### DIFF
--- a/chitchat/src/lib.rs
+++ b/chitchat/src/lib.rs
@@ -22,7 +22,7 @@ use delta::Delta;
 use failure_detector::FailureDetector;
 pub use failure_detector::FailureDetectorConfig;
 pub use listener::ListenerHandle;
-pub use serialize::Serializable;
+pub use serialize::{Deserializable, Serializable};
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 use tracing::{error, info, warn};

--- a/chitchat/src/serialize.rs
+++ b/chitchat/src/serialize.rs
@@ -23,6 +23,11 @@ pub trait Serializable {
     fn serialized_len(&self) -> usize;
 }
 
+/// Trait to deserialize messages.
+///
+/// Chitchat uses a custom binary serialization format.
+/// The point of this format is to make it possible
+/// to truncate the delta payload to a given mtu.
 pub trait Deserializable: Sized {
     fn deserialize(buf: &mut &[u8]) -> anyhow::Result<Self>;
 }


### PR DESCRIPTION
These changes help developers implement custom transports that need to serialize and deserialize messages. #106 #78