### PR TITLE
Fix edition 2024 impl capture

### DIFF
--- a/chitchat/src/server.rs
+++ b/chitchat/src/server.rs
@@ -200,7 +200,7 @@ impl ChitchatHandle {
         Ok(())
     }
 
-    pub fn termination_watcher(&self) -> impl Future<Output = anyhow::Result<()>> {
+    pub fn termination_watcher(&self) -> impl Future<Output = anyhow::Result<()>> + use<> {
         let mut watcher = self.termination_watcher.clone();
         async move {
             let termination_res = watcher.wait_for(|res| res.is_some()).await;


### PR DESCRIPTION
This used to work before the 2024 upgrade but impl now captures more by default (see https://blog.rust-lang.org/2024/09/05/impl-trait-capture-rules/)