### PR TITLE
Do not stop gossip loop on transient UDP recv errors

### DIFF
--- a/chitchat/src/server.rs
+++ b/chitchat/src/server.rs
@@ -246,7 +246,7 @@ impl Server {
                     Ok((from_addr, message)) => {
                         let _ = self.handle_message(from_addr, message).await;
                     }
-                    Err(err) => return Err(err),
+                    Err(err) => warn!("UDP recv error: {err:#}"),
                 },
                 _ = gossip_interval.tick() => {
                     self.gossip_multiple().await


### PR DESCRIPTION
## Summary
- Log and continue instead of returning on UDP recv errors in the server loop
- A transient error (e.g. `ENOBUFS`) previously killed the entire gossip loop

Closes #145. Supersedes #146 — same fix, rebased on current main without the signature changes.

## Test plan
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)