### PR TITLE
Replace return with warn! in server loop

### DIFF
--- a/chitchat/src/server.rs
+++ b/chitchat/src/server.rs
@@ -246,7 +246,7 @@ impl Server {
                     Ok((from_addr, message)) => {
                         let _ = self.handle_message(from_addr, message).await;
                     }
-                    Err(err) => return Err(err),
+                    Err(err) => warn!("communication error: {err:#}"),
                 },
                 _ = gossip_interval.tick() => {
                     self.gossip_multiple().await


### PR DESCRIPTION
## Summary
- Log and continue instead of returning on UDP recv errors in the server loop
- A transient error previously killed the entire gossip loop

Rebased version of #146 by @cattuz on current main. Original contributor is preserved as commit author.

Closes #145