### PR TITLE
Reverts previous range to stick with the original philosophy of socket.

### DIFF
--- a/chitchat/src/server.rs
+++ b/chitchat/src/server.rs
@@ -246,7 +246,12 @@ impl Server {
                     Ok((from_addr, message)) => {
                         let _ = self.handle_message(from_addr, message).await;
                     }
-                    Err(err) => warn!("communication error: {err:#}"),
+                    // Transient errors (e.g. ENOBUFS) are swallowed inside
+                    // Socket::recv. An error here means the socket is broken.
+                    Err(err) => {
+                        warn!(err=%err, "fatal UDP recv error, stopping gossip loop");
+                        return Err(err);
+                    }
                 },
                 _ = gossip_interval.tick() => {
                     self.gossip_multiple().await

--- a/chitchat/src/transport/udp.rs
+++ b/chitchat/src/transport/udp.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::net::SocketAddr;
 
 use anyhow::Context;
@@ -37,6 +38,17 @@ impl UdpSocket {
     }
 }
 
+fn is_transient_io_error(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::OutOfMemory
+            // On Windows, sending to a closed peer causes recv_from to fail
+            // with ConnectionReset (WSAECONNRESET / 10054).
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::ConnectionRefused
+    )
+}
+
 #[async_trait]
 impl Socket for UdpSocket {
     async fn send(&mut self, to_addr: SocketAddr, message: ChitchatMessage) -> anyhow::Result<()> {
@@ -58,11 +70,16 @@ impl Socket for UdpSocket {
 
 impl UdpSocket {
     async fn receive_one(&mut self) -> anyhow::Result<Option<(SocketAddr, ChitchatMessage)>> {
-        let (len, from_addr) = self
-            .socket
-            .recv_from(&mut self.buf_recv[..])
-            .await
-            .context("Error while receiving UDP message")?;
+        let (len, from_addr) = match self.socket.recv_from(&mut self.buf_recv[..]).await {
+            Ok(result) => result,
+            Err(err) if is_transient_io_error(&err) => {
+                warn!(error=%err, "transient UDP recv error");
+                return Ok(None);
+            }
+            Err(err) => {
+                return Err(err).context("fatal UDP recv error");
+            }
+        };
         let mut buf = &self.buf_recv[..len];
         match ChitchatMessage::deserialize(&mut buf) {
             Ok(msg) => Ok(Some((from_addr, msg))),


### PR DESCRIPTION
We classify transient error within the Socket (they are socket specific after all) and swallow them without surfacing them to the client.

We only emit fatal errors.

The PR also improves the error detection to include the windows specific windows behavior described in #146.

Closes #146