### PR TITLE
Bugfix on grpc chitchat reset causing assert failure

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2,7 +2,6 @@ Component,Origin,License,Copyright
 allocator-api2,https://github.com/zakarumych/allocator-api2,MIT OR Apache-2.0,Zakarum <zaq.dev@icloud.com>
 anyhow,https://github.com/dtolnay/anyhow,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 async-trait,https://github.com/dtolnay/async-trait,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
-bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project Developers
 bytes,https://github.com/tokio-rs/bytes,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 chacha20,https://github.com/RustCrypto/stream-ciphers,MIT OR Apache-2.0,RustCrypto Developers
@@ -13,34 +12,29 @@ foldhash,https://github.com/orlp/foldhash,Zlib,Orson Peters <orsonpeters@gmail.c
 futures-core,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-core Authors
 futures-sink,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-sink Authors
 getrandom,https://github.com/rust-random/getrandom,MIT OR Apache-2.0,The Rand Project Developers
-hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,The hashbrown Authors
-heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
-id-arena,https://github.com/fitzgen/id-arena,MIT OR Apache-2.0,"Nick Fitzgerald <fitzgen@gmail.com>, Aleksey Kladov <aleksey.kladov@gmail.com>"
-indexmap,https://github.com/indexmap-rs/indexmap,Apache-2.0 OR MIT,The indexmap Authors
 itertools,https://github.com/rust-itertools/itertools,MIT OR Apache-2.0,bluss
-itoa,https://github.com/dtolnay/itoa,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
-leb128fmt,https://github.com/bluk/leb128fmt,MIT OR Apache-2.0,Bryant Luk <code@bryantluk.com>
+lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
 libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Developers
 log,https://github.com/rust-lang/log,MIT OR Apache-2.0,The Rust Project Developers
 lru,https://github.com/jeromefroe/lru-rs,MIT,Jerome Froelich <jeromefroelic@hotmail.com>
-memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
 mio,https://github.com/tokio-rs/mio,MIT,"Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>"
+nu-ansi-term,https://github.com/nushell/nu-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>, The Nushell Project Developers"
 once_cell,https://github.com/matklad/once_cell,MIT OR Apache-2.0,Aleksey Kladov <aleksey.kladov@gmail.com>
 pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,The pin-project-lite Authors
-prettyplease,https://github.com/dtolnay/prettyplease,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>"
 quote,https://github.com/dtolnay/quote,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 r-efi,https://github.com/r-efi/r-efi,MIT OR Apache-2.0 OR LGPL-2.1-or-later,The r-efi Authors
 rand,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_core,https://github.com/rust-random/rand_core,MIT OR Apache-2.0,The Rand Project Developers
-semver,https://github.com/dtolnay/semver,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_core,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_derive,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
-serde_json,https://github.com/serde-rs/json,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
+sharded-slab,https://github.com/hawkw/sharded-slab,MIT,Eliza Weisman <eliza@buoyant.io>
+smallvec,https://github.com/servo/rust-smallvec,MIT OR Apache-2.0,The Servo Project Developers
 socket2,https://github.com/rust-lang/socket2,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>"
 syn,https://github.com/dtolnay/syn,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+thread_local,https://github.com/Amanieu/thread_local-rs,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 tokio,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
 tokio-macros,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
 tokio-stream,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
@@ -48,24 +42,13 @@ tokio-util,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.
 tracing,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, Tokio Contributors <team@tokio.rs>"
 tracing-attributes,https://github.com/tokio-rs/tracing,MIT,"Tokio Contributors <team@tokio.rs>, Eliza Weisman <eliza@buoyant.io>, David Barsky <dbarsky@amazon.com>"
 tracing-core,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
+tracing-log,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
+tracing-subscriber,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, David Barsky <me@davidbarsky.com>, Tokio Contributors <team@tokio.rs>"
 unicode-ident,https://github.com/dtolnay/unicode-ident,(MIT OR Apache-2.0) AND Unicode-3.0,David Tolnay <dtolnay@gmail.com>
-unicode-xid,https://github.com/unicode-rs/unicode-xid,MIT OR Apache-2.0,"erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
 valuable,https://github.com/tokio-rs/valuable,MIT,The valuable Authors
 wasi,https://github.com/bytecodealliance/wasi,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,The Cranelift Project Developers
-wasip2,https://github.com/bytecodealliance/wasi-rs,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,The wasip2 Authors
-wasip3,https://github.com/bytecodealliance/wasi-rs,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,The wasip3 Authors
-wasm-encoder,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Nick Fitzgerald <fitzgen@gmail.com>
-wasm-metadata,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,The wasm-metadata Authors
-wasmparser,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Yury Delendik <ydelendik@mozilla.com>
 windows-link,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-link Authors
 windows-sys,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-sys Authors
-wit-bindgen,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-wit-bindgen-core,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-wit-bindgen-rust,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-wit-bindgen-rust-macro,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-wit-component,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Peter Huene <peter@huene.dev>
-wit-parser,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-zmij,https://github.com/dtolnay/zmij,MIT,David Tolnay <dtolnay@gmail.com>
 zstd,https://github.com/gyscos/zstd-rs,MIT,Alexandre Bury <alexandre.bury@gmail.com>
 zstd-safe,https://github.com/gyscos/zstd-rs,MIT OR Apache-2.0,Alexandre Bury <alexandre.bury@gmail.com>
 zstd-sys,https://github.com/gyscos/zstd-rs,MIT OR Apache-2.0,Alexandre Bury <alexandre.bury@gmail.com>

--- a/chitchat/Cargo.toml
+++ b/chitchat/Cargo.toml
@@ -27,11 +27,12 @@ tokio = { version = "1.28.0", features = [
 ] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", optional = true }
 zstd = "0.13"
 
 [dev-dependencies]
 assert-json-diff = "2"
-tracing-subscriber = "0.3"
+chitchat = { path = ".", features = ["testsuite"] }
 proptest = "1.4"
 tokio = { version = "1.28.0", features = [
     "net",
@@ -43,4 +44,4 @@ tokio = { version = "1.28.0", features = [
 ] }
 
 [features]
-testsuite = []
+testsuite = ["tracing-subscriber"]

--- a/chitchat/Cargo.toml
+++ b/chitchat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chitchat"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 license = "MIT"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]

--- a/chitchat/src/lib.rs
+++ b/chitchat/src/lib.rs
@@ -35,6 +35,22 @@ pub use crate::server::{ChitchatHandle, spawn_chitchat};
 use crate::state::ClusterState;
 pub use crate::types::{ChitchatId, DeletionStatus, Heartbeat, Version, VersionedValue};
 
+/// Sets up a tracing subscriber writing to the test harness's captured
+/// output, so `cargo test` can display logs on failure.
+///
+/// Guarded by a `OnceLock` because `tracing::subscriber::set_global_default`
+/// can only be called once per process, and all tests in a given test
+/// binary run in the same process.
+#[cfg(any(test, feature = "testsuite"))]
+pub fn setup_tracing_for_tests() {
+    use std::sync::OnceLock;
+
+    static TRACING_INIT: OnceLock<()> = OnceLock::new();
+    TRACING_INIT.get_or_init(|| {
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    });
+}
+
 /// Maximum UDP datagram payload size (in bytes).
 ///
 /// Note that 65KB typically won't fit in a single IP packet,
@@ -654,7 +670,7 @@ mod tests {
         // needs a reset, and a single delta would:
         // - not increase its max version after reset.
         // - not even bring the state to a max_version >= last_gc_version
-        // let _ = tracing_subscriber::fmt::try_init();
+        setup_tracing_for_tests();
         tokio::time::pause();
         let node_config1 = ChitchatConfig::for_test(10_001);
         let empty_seeds = watch::channel(Default::default()).1;

--- a/chitchat/src/lib.rs
+++ b/chitchat/src/lib.rs
@@ -355,15 +355,13 @@ impl Chitchat {
             return;
         };
 
-        if node_state.max_version() >= max_version {
-            info!("attempted to reset node, but node is already up to date");
-            return;
-        }
+        let monotonic_property_before: (Version, Version) = node_state.monotonic_property();
+        let monotonic_property_if_we_applied_reset_state: (Version, Version) =
+            (last_gc_version, max_version);
 
-        if max_version < node_state.last_gc_version() {
-            // It is possible to have gc_version > max_version when we are catching up.
-            // If we reach this point, we probably went through a reset via chitchat gossip.
-            //
+        if monotonic_property_before >= monotonic_property_if_we_applied_reset_state {
+            // If we reach this point, we had a race condition and went through a reset via chitchat
+            // gossip.
             // Now we are trying to reset our state via grpc gossip, but the new state is already
             // be out of date.
             warn!(
@@ -371,12 +369,10 @@ impl Chitchat {
                 node_last_gc_version = node_state.last_gc_version(),
                 delta_max_version = max_version,
                 delta_last_gc_version = last_gc_version,
-                "attempted to reset node with an obsolete state"
+                "attempted to reset node with an obsolete state (rare race condition)"
             );
             return;
         }
-
-        let monotonic_property_before = node_state.monotonic_property();
 
         // We make sure that the node is listed in the failure detector,
         // so that we won't forget to GC the state.
@@ -385,6 +381,8 @@ impl Chitchat {
         // avoid identifying resetted node as alive.
         self.failure_detector
             .get_or_create_sampling_window(chitchat_id);
+
+        node_state.set_max_version(max_version);
 
         // We don't want to call listeners for keys that are already up to date so we must do this
         // dance instead of clearing the node state and then setting the new values.
@@ -656,7 +654,7 @@ mod tests {
         // needs a reset, and a single delta would:
         // - not increase its max version after reset.
         // - not even bring the state to a max_version >= last_gc_version
-        let _ = tracing_subscriber::fmt::try_init();
+        // let _ = tracing_subscriber::fmt::try_init();
         tokio::time::pause();
         let node_config1 = ChitchatConfig::for_test(10_001);
         let empty_seeds = watch::channel(Default::default()).1;
@@ -1263,7 +1261,6 @@ mod tests {
         node_state.set("foo", "bar");
         node_state.set("qux", "baz");
         node_state.set("toto", "titi");
-
         node.reset_node_state_if_update(
             &chitchat_id,
             [
@@ -1281,11 +1278,88 @@ mod tests {
             1337,
         );
         let node_state = node.cluster_state.node_state(&chitchat_id).unwrap();
-        assert_eq!(node_state.num_key_values(), 3);
+        assert_eq!(node_state.num_key_values(), 2);
         assert_eq!(node_state.get("foo"), Some("bar"));
         assert_eq!(node_state.get("qux"), Some("baz"));
-        assert_eq!(node_state.get("toto"), Some("titi"));
-        assert_eq!(node_state.max_version(), 3);
+        assert_eq!(node_state.max_version(), 2);
+        assert_eq!(node_state.last_gc_version(), 1337);
+    }
+
+    // grpc/catchup path: between the time the catchup grpc is issued and the time it returns,
+    // this node received a gossip-driven reset that advanced its `last_gc_version`
+    // ahead of the (now stale) catchup source. The source has newer data
+    // (`max_version` 120 > our 100) but an older GC horizon
+    // (`last_gc_version` 80 < our 100).
+    //
+    // The reset must be rejected.
+    #[tokio::test]
+    async fn test_reset_node_state_does_not_regress_last_gc_version_reproduces_194() {
+        let config = ChitchatConfig::for_test(10_010);
+        let (_seed_addrs_rx, seed_addrs_tx) = watch::channel(Default::default());
+        let mut node = Chitchat::with_chitchat_id_and_seeds(config, seed_addrs_tx, Vec::new());
+
+        let chitchat_id = ChitchatId::for_local_test(10_011);
+        let node_state = node.cluster_state.node_state_mut_or_init(&chitchat_id);
+        node_state.set_max_version(100);
+        node_state.set_last_gc_version(100);
+        node.reset_node_state_if_update(
+            &chitchat_id,
+            [(
+                "a".to_string(),
+                VersionedValue::new("v".to_string(), 120, false),
+            )]
+            .into_iter(),
+            120,
+            80,
+        );
+
+        // The obsolete-gc snapshot is rejected and the node is left untouched.
+        let node_state = node.cluster_state.node_state(&chitchat_id).unwrap();
+        assert_eq!(node_state.max_version(), 100);
+        assert_eq!(node_state.last_gc_version(), 100);
+        assert_eq!(node_state.get("a"), None);
+    }
+
+    // Regression test: the catchup path must adopt the snapshot's `max_version`,
+    // even when no live key-value reaches it.
+    //
+    // A node's `max_version` reflects the highest version among its key-values
+    // *including tombstones*. Once tombstones past the grace period are GC'd,
+    // `max_version` can exceed the highest *present* key-value version. So a
+    // catchup snapshot can legitimately report `max_version` 100 while its
+    // highest live key-value is only at version 50 (versions 51..100 were
+    // deletions GC'd at the source).
+    #[tokio::test]
+    async fn test_reset_node_state_adopts_snapshot_max_version_reproduces_194() {
+        let config = ChitchatConfig::for_test(10_012);
+        let (_seed_addrs_rx, seed_addrs_tx) = watch::channel(Default::default());
+        let mut node = Chitchat::with_chitchat_id_and_seeds(config, seed_addrs_tx, Vec::new());
+
+        let chitchat_id = ChitchatId::for_local_test(10_013);
+        let node_state = node.cluster_state.node_state_mut_or_init(&chitchat_id);
+        node_state.set_versioned_value(
+            "old".to_string(),
+            VersionedValue::new("x".to_string(), 50, false),
+        );
+        node_state.set_last_gc_version(10);
+        assert_eq!(node_state.max_version(), 50);
+
+        node.reset_node_state_if_update(
+            &chitchat_id,
+            [(
+                "a".to_string(),
+                VersionedValue::new("v".to_string(), 50, false),
+            )]
+            .into_iter(),
+            100,
+            10,
+        );
+
+        let node_state = node.cluster_state.node_state(&chitchat_id).unwrap();
+        assert_eq!(node_state.max_version(), 100);
+        assert_eq!(node_state.last_gc_version(), 10);
+        assert_eq!(node_state.get("a"), Some("v"));
+        assert_eq!(node_state.get("old"), None);
     }
 
     #[tokio::test]

--- a/chitchat/tests/cluster_test.rs
+++ b/chitchat/tests/cluster_test.rs
@@ -487,7 +487,7 @@ fn find_available_tcp_port() -> anyhow::Result<u16> {
 
 #[tokio::test]
 async fn test_simple_simulation_insert() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     let (catchup_callback_tx, mut catchup_callback_rx) = tokio::sync::mpsc::unbounded_channel();
     let mut simulator = Simulator::new(Duration::from_millis(100), Duration::from_secs(1));
     simulator.catchup_callback_tx = Some(catchup_callback_tx);
@@ -595,7 +595,7 @@ async fn test_simple_simulation_delete_after_ttl() {
 
 #[tokio::test]
 async fn test_simple_simulation_with_network_partition() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     let mut simulator = Simulator::new(Duration::from_millis(100), Duration::from_secs(1));
     let chitchat_id_1 = create_chitchat_id("node-1");
     let chitchat_id_2 = create_chitchat_id("node-2");
@@ -637,7 +637,7 @@ async fn test_simple_simulation_with_network_partition() {
 
 #[tokio::test]
 async fn test_marked_for_deletion_gc_with_network_partition_2_nodes() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     const TIMEOUT: Duration = Duration::from_millis(500);
     let mut simulator = Simulator::new(Duration::from_millis(100), Duration::from_secs(1));
     let chitchat_id_1 = test_chitchat_id(1);
@@ -707,7 +707,7 @@ async fn test_marked_for_deletion_gc_with_network_partition_2_nodes() {
 
 #[tokio::test]
 async fn test_marked_for_deletion_gc_with_network_partition_4_nodes() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     const TIMEOUT: Duration = Duration::from_millis(500);
     let mut simulator = Simulator::new(Duration::from_millis(100), Duration::from_secs(1));
     let chitchat_id_1 = test_chitchat_id(1);
@@ -831,7 +831,7 @@ async fn test_marked_for_deletion_gc_with_network_partition_4_nodes() {
 // of nodes to 3 and keys to 1 or 2.
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_simple_simulation_heavy_insert_delete() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     let mut rng = rng();
     let mut simulator = Simulator::new(Duration::from_millis(100), Duration::from_secs(5));
     let mut chitchat_ids = Vec::new();
@@ -921,7 +921,7 @@ async fn test_simple_simulation_heavy_insert_delete() {
 
 #[tokio::test]
 async fn test_garbage_collected_node_only_recreated_if_new_heartbeat() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     const PROPAGATION_TIMEOUT: Duration = Duration::from_millis(500);
     const NODE_DELETION_GRACE_PERIOD: Duration = Duration::from_secs(4);
     let mut simulator = Simulator::new(Duration::from_millis(100), Duration::from_secs(1));
@@ -1006,7 +1006,7 @@ async fn test_garbage_collected_node_only_recreated_if_new_heartbeat() {
 
 #[tokio::test]
 async fn test_catchup_callback_after_partition() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     const PROPAGATION_TIMEOUT: Duration = Duration::from_millis(500);
     const KV_DELETION_GRACE_PERIOD: Duration = Duration::from_secs(1);
     let (catchup_callback_tx, mut catchup_callback_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/chitchat/tests/cluster_test.rs
+++ b/chitchat/tests/cluster_test.rs
@@ -707,7 +707,7 @@ async fn test_marked_for_deletion_gc_with_network_partition_2_nodes() {
 
 #[tokio::test]
 async fn test_marked_for_deletion_gc_with_network_partition_4_nodes() {
-    let _ = tracing_subscriber::fmt::try_init();
+    // let _ = tracing_subscriber::fmt::try_init();
     const TIMEOUT: Duration = Duration::from_millis(500);
     let mut simulator = Simulator::new(Duration::from_millis(100), Duration::from_secs(1));
     let chitchat_id_1 = test_chitchat_id(1);
@@ -921,7 +921,7 @@ async fn test_simple_simulation_heavy_insert_delete() {
 
 #[tokio::test]
 async fn test_garbage_collected_node_only_recreated_if_new_heartbeat() {
-    let _ = tracing_subscriber::fmt::try_init();
+    // let _ = tracing_subscriber::fmt::try_init();
     const PROPAGATION_TIMEOUT: Duration = Duration::from_millis(500);
     const NODE_DELETION_GRACE_PERIOD: Duration = Duration::from_secs(4);
     let mut simulator = Simulator::new(Duration::from_millis(100), Duration::from_secs(1));
@@ -1006,7 +1006,7 @@ async fn test_garbage_collected_node_only_recreated_if_new_heartbeat() {
 
 #[tokio::test]
 async fn test_catchup_callback_after_partition() {
-    let _ = tracing_subscriber::fmt::try_init();
+    // let _ = tracing_subscriber::fmt::try_init();
     const PROPAGATION_TIMEOUT: Duration = Duration::from_millis(500);
     const KV_DELETION_GRACE_PERIOD: Duration = Duration::from_secs(1);
     let (catchup_callback_tx, mut catchup_callback_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/chitchat/tests/perf_test.rs
+++ b/chitchat/tests/perf_test.rs
@@ -77,7 +77,7 @@ async fn delay_before_detection_sample(num_nodes: usize, transport: &dyn Transpo
 
 #[tokio::test]
 async fn test_delay_before_dead_detection_10() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     let transport = ChannelTransport::with_mtu(65_507);
     let delay = delay_before_detection_sample(40, &transport).await;
     assert!(
@@ -89,7 +89,7 @@ async fn test_delay_before_dead_detection_10() {
 
 #[tokio::test]
 async fn test_delay_before_dead_detection_20() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     let transport = ChannelTransport::with_mtu(65_507);
     let delay = delay_before_detection_sample(20, &transport).await;
     assert!(
@@ -101,7 +101,7 @@ async fn test_delay_before_dead_detection_20() {
 
 #[tokio::test]
 async fn test_delay_before_dead_detection_40() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     let transport = ChannelTransport::with_mtu(65_507);
     let delay = delay_before_detection_sample(40, &transport).await;
     assert!(
@@ -113,7 +113,7 @@ async fn test_delay_before_dead_detection_40() {
 
 #[tokio::test]
 async fn test_delay_before_dead_detection_100() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     let transport = ChannelTransport::with_mtu(65_507);
     let delay = delay_before_detection_sample(100, &transport).await;
     assert!(
@@ -125,7 +125,7 @@ async fn test_delay_before_dead_detection_100() {
 
 #[tokio::test]
 async fn test_delay_before_dead_detection_100_faulty() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     let transport = ChannelTransport::with_mtu(65_507).drop_message(0.5f64);
     let delay = delay_before_detection_sample(100, &*transport).await;
     assert!(
@@ -136,7 +136,7 @@ async fn test_delay_before_dead_detection_100_faulty() {
 }
 
 async fn test_bandwidth_aux(num_nodes: usize) -> u64 {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     assert!(num_nodes > 2);
     let transport = ChannelTransport::with_mtu(65_507);
     let handles = spawn_nodes(num_nodes as u16, &transport).await;
@@ -163,26 +163,26 @@ async fn test_bandwidth_aux(num_nodes: usize) -> u64 {
 
 #[tokio::test]
 async fn test_bandwidth_10() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     assert!(test_bandwidth_aux(10).await < 15_000);
 }
 
 #[tokio::test]
 async fn test_bandwidth_20() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     test_bandwidth_aux(20).await;
     assert!(test_bandwidth_aux(20).await < 25_000);
 }
 
 #[tokio::test]
 async fn test_bandwidth_40() {
-    let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     assert!(test_bandwidth_aux(40).await < 50_000);
 }
 
 #[tokio::test]
 async fn test_bandwidth_100() {
-    let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     assert!(test_bandwidth_aux(100).await < 120_000);
 }
 
@@ -205,7 +205,7 @@ async fn test_faulty_network_stability_aux(num_nodes: usize, transport: &dyn Tra
 
 #[tokio::test]
 async fn test_faulty_network_stability_10() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     // 50% messages are dropped.
     use chitchat::transport::TransportExt;
     let transport: Box<dyn Transport> = ChannelTransport::with_mtu(65_507).drop_message(0.5f64);
@@ -214,7 +214,7 @@ async fn test_faulty_network_stability_10() {
 
 #[tokio::test]
 async fn test_faulty_network_stability_100() {
-    // let _ = tracing_subscriber::fmt::try_init();
+    chitchat::setup_tracing_for_tests();
     // 50% messages are dropped.
     use chitchat::transport::TransportExt;
     let transport: Box<dyn Transport> = ChannelTransport::with_mtu(65_507).drop_message(0.5f64);

--- a/chitchat/tests/perf_test.rs
+++ b/chitchat/tests/perf_test.rs
@@ -125,7 +125,7 @@ async fn test_delay_before_dead_detection_100() {
 
 #[tokio::test]
 async fn test_delay_before_dead_detection_100_faulty() {
-    let _ = tracing_subscriber::fmt::try_init();
+    // let _ = tracing_subscriber::fmt::try_init();
     let transport = ChannelTransport::with_mtu(65_507).drop_message(0.5f64);
     let delay = delay_before_detection_sample(100, &*transport).await;
     assert!(
@@ -136,7 +136,7 @@ async fn test_delay_before_dead_detection_100_faulty() {
 }
 
 async fn test_bandwidth_aux(num_nodes: usize) -> u64 {
-    let _ = tracing_subscriber::fmt::try_init();
+    // let _ = tracing_subscriber::fmt::try_init();
     assert!(num_nodes > 2);
     let transport = ChannelTransport::with_mtu(65_507);
     let handles = spawn_nodes(num_nodes as u16, &transport).await;
@@ -163,13 +163,13 @@ async fn test_bandwidth_aux(num_nodes: usize) -> u64 {
 
 #[tokio::test]
 async fn test_bandwidth_10() {
-    let _ = tracing_subscriber::fmt::try_init();
+    // let _ = tracing_subscriber::fmt::try_init();
     assert!(test_bandwidth_aux(10).await < 15_000);
 }
 
 #[tokio::test]
 async fn test_bandwidth_20() {
-    let _ = tracing_subscriber::fmt::try_init();
+    // let _ = tracing_subscriber::fmt::try_init();
     test_bandwidth_aux(20).await;
     assert!(test_bandwidth_aux(20).await < 25_000);
 }
@@ -205,7 +205,7 @@ async fn test_faulty_network_stability_aux(num_nodes: usize, transport: &dyn Tra
 
 #[tokio::test]
 async fn test_faulty_network_stability_10() {
-    let _ = tracing_subscriber::fmt::try_init();
+    // let _ = tracing_subscriber::fmt::try_init();
     // 50% messages are dropped.
     use chitchat::transport::TransportExt;
     let transport: Box<dyn Transport> = ChannelTransport::with_mtu(65_507).drop_message(0.5f64);
@@ -214,7 +214,7 @@ async fn test_faulty_network_stability_10() {
 
 #[tokio::test]
 async fn test_faulty_network_stability_100() {
-    let _ = tracing_subscriber::fmt::try_init();
+    // let _ = tracing_subscriber::fmt::try_init();
     // 50% messages are dropped.
     use chitchat::transport::TransportExt;
     let transport: Box<dyn Transport> = ChannelTransport::with_mtu(65_507).drop_message(0.5f64);


### PR DESCRIPTION
Chitchat offers an API to reset a node state.
Quickwit uses it to bring node to an up to date
state using a gRPC call.

We observed an assert failure of the monotonic assert in prod.

There are in fact two possible cause of failure:
- a race condition between a chitchat reset and the gRPC. In that case, the grpc reset would bring us to an anterior gc version.

- a node max version that is higher that the highest KV version. This is possible if the KV with max version was GC'ed. In that case, we were forgetting to set max version and ended up with breaking the monotonic contraint.

Both failure mode are now caught in a unit test.

The solution is not trying to be smart.
We now explicitly reject grpc calls that would not strictly increase the monotonic property.

We kept the rejection on gRPC reset that do not increase max_version too.

We also do set max_version at the end of the call.

Closes #194