### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/chitchat-test/Cargo.toml
+++ b/chitchat-test/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.86"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chitchat = { version = "0.11.0", path = "../chitchat" }
+chitchat = { version = "0.12.0", path = "../chitchat" }
 poem = "3.1.11"
 poem-openapi = {version="5.1.15", features = ["swagger-ui"] }
 structopt = "0.3"

--- a/chitchat/Cargo.toml
+++ b/chitchat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chitchat"
-version = "0.11.2"
+version = "0.12.0"
 edition = "2024"
 license = "MIT"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]


### PR DESCRIPTION
## Summary
- Bump chitchat crate version to 0.12.0
- Update chitchat-test's path dependency to match